### PR TITLE
ITM-178: Add script to add admin users to production

### DIFF
--- a/deployment_script.py
+++ b/deployment_script.py
@@ -3,11 +3,12 @@ import os
 from scripts._0_0_3_add_eval_3_adm_data import add_eval_3_adm_data
 from scripts._0_0_4_update_human_sim_records import update_hum_sim_order_avg_across_scenes
 from scripts._0_0_5_remove_old_adm_data import remove_old_adm_records
+from scripts._0_0_6_set_admin_users import add_admin_user_role
 
 VERSION_COLLECTION = "itm_version"
 
 # Change this version if running a new deploy script
-db_version = "0.0.5"
+db_version = "0.0.6"
 
 
 def check_version(mongoDB):
@@ -40,6 +41,7 @@ def main():
         update_hum_sim_order_avg_across_scenes(mongoDB)
         remove_old_adm_records(mongoDB)
         add_eval_3_adm_data(mongoDB)
+        add_admin_user_role(mongoDB)
 
         # Run Script for Probe Matching and importing human data
         os.system("python3 probe_matcher.py -i metrics-data/")

--- a/scripts/_0_0_6_set_admin_users.py
+++ b/scripts/_0_0_6_set_admin_users.py
@@ -1,0 +1,12 @@
+# Note:  Only current dev users in prod (admins can make others admins and assign other roles)
+admin_prod_users = ["bpippin", "jennifer", "phile", "derek"]
+
+def add_admin_user_role(mongoDB):
+    users_collection = mongoDB['users']
+
+    for user in admin_prod_users:
+        matching_user = users_collection.find_one({"username": user})
+        matching_user["admin"] = True
+        users_collection.replace_one({"_id": matching_user["_id"]}, matching_user)
+
+    print("Completed adding admin role.")


### PR DESCRIPTION
Two Notes here:

1.  If you want to test the corresponding UI ticket that goes with this, you might want to add your local username to this script before you run it.
2. We are still running all the old scripts because we haven't pushed ingest to main.  We want one script call that will run all the scripts on production, ideally in the future, we merge one script to main at a time.