### PR TITLE
Itm 346

### DIFF
--- a/scripts/_0_0_8_add_textbased_alignment.py
+++ b/scripts/_0_0_8_add_textbased_alignment.py
@@ -11,10 +11,8 @@ def load_scenario_config(scenario_name):
         with open(config_file, 'r') as file:
             return json.load(file)
     except FileNotFoundError:
-        print(f"Configuration file not found: {config_file}")
         return None
     except json.JSONDecodeError:
-        print(f"Error decoding JSON from the file: {config_file}")
         return None
     
 scenarioMappings = {
@@ -120,7 +118,7 @@ def submit_responses(scenario_results, scenario_id, url_base, session_id):
                     response = requests.post(response_url, json=response_payload)
                     responses.append(response)
                 except requests.RequestException as e:
-                    print(f"Failed to send response for {question_name}: {e}")      
+                    continue   
     return responses
 
 
@@ -142,8 +140,6 @@ def get_adept_alignment(scenario_results, scenario_id):
         # remove field from previous script that just held HIGH alignment
         scenario_results['alignmentData'] = ""
         scenario_results['serverSessionId'] = session_id
-        print(scenario_results['highAlignmentData'])
-        print(scenario_results['lowAlignmentData'])
 
 def get_soartech_alignment(scenario_results, scenario_id):
     url = f"{ST_URL}/api/v1/new_session?user_id=default_user"
@@ -158,8 +154,6 @@ def get_soartech_alignment(scenario_results, scenario_id):
         # remove field from previous script that just held HIGH alignment
         scenario_results['alignmentData'] = ""
         scenario_results['serverSessionId'] = session_id
-        print(scenario_results['highAlignmentData'])
-        print(scenario_results['lowAlignmentData'])
 
 def load_problem_probes():
     problem_probes_file = os.path.join(CONFIG_PATH, 'problemProbes.json')
@@ -167,10 +161,8 @@ def load_problem_probes():
         with open(problem_probes_file, 'r') as file:
             return json.load(file)
     except FileNotFoundError:
-        print(f"Problem probes configuration file not found: {problem_probes_file}")
         return {}
     except json.JSONDecodeError:
-        print(f"Error decoding JSON from the file: {problem_probes_file}")
         return {}
 
 
@@ -209,11 +201,13 @@ def add_textbased_alignments(mongo_db):
         elif "SoarTech" in result.get('title'):
             get_soartech_alignment(result, scenarioNameToID.get(result.get('title')))
         else:
-            print("Error: unrecognized scenario title")
+            continue
 
         user_scenario_results_collection.update_one(
             {'_id': result['_id']},
             {'$set': result}
         )
+
+    print("TextBased Alignment Scores Added to Mongo")
 
 

--- a/scripts/_0_0_8_add_textbased_alignment.py
+++ b/scripts/_0_0_8_add_textbased_alignment.py
@@ -140,7 +140,7 @@ def get_adept_alignment(scenario_results, scenario_id):
         scenario_results['highAlignmentData'] = high_alignment_data
         scenario_results['lowAlignmentData'] = low_alignment_data
         # remove field from previous script that just held HIGH alignment
-        scenario_results['alignmentData'] = None
+        scenario_results['alignmentData'] = ""
         scenario_results['serverSessionId'] = session_id
         print(scenario_results['highAlignmentData'])
         print(scenario_results['lowAlignmentData'])
@@ -156,7 +156,7 @@ def get_soartech_alignment(scenario_results, scenario_id):
         scenario_results['highAlignmentData'] = high_alignment_data
         scenario_results['lowAlignmentData'] = low_alignment_data 
         # remove field from previous script that just held HIGH alignment
-        scenario_results['alignmentData'] = None
+        scenario_results['alignmentData'] = ""
         scenario_results['serverSessionId'] = session_id
         print(scenario_results['highAlignmentData'])
         print(scenario_results['lowAlignmentData'])

--- a/scripts/_0_0_8_add_textbased_alignment.py
+++ b/scripts/_0_0_8_add_textbased_alignment.py
@@ -135,8 +135,8 @@ def get_adept_alignment(scenario_results, scenario_id):
     if start_session.status_code == 200:
         session_id = start_session.json()
         responses = submit_responses(scenario_results, scenario_id, ADEPT_URL, session_id)
-        high_alignment_data = get_alignment_data(ADEPT_URL, session_id, 'ADEPT-metrics_eval-alignment-target-train-HIGH')
-        low_alignment_data = get_alignment_data(ADEPT_URL, session_id, 'ADEPT-metrics_eval-alignment-target-train-LOW')
+        high_alignment_data = get_alignment_data(ADEPT_URL, session_id, 'ADEPT-metrics_eval-alignment-target-eval-HIGH')
+        low_alignment_data = get_alignment_data(ADEPT_URL, session_id, 'ADEPT-metrics_eval-alignment-target-eval-LOW')
         scenario_results['highAlignmentData'] = high_alignment_data
         scenario_results['lowAlignmentData'] = low_alignment_data
         # remove field from previous script that just held HIGH alignment

--- a/scripts/_0_0_8_add_textbased_alignment.py
+++ b/scripts/_0_0_8_add_textbased_alignment.py
@@ -135,10 +135,13 @@ def get_adept_alignment(scenario_results, scenario_id):
     if start_session.status_code == 200:
         session_id = start_session.json()
         responses = submit_responses(scenario_results, scenario_id, ADEPT_URL, session_id)
-        alignment_data = get_alignment_data(ADEPT_URL, session_id, 'ADEPT-metrics_eval-alignment-target-train-HIGH')
-        scenario_results['alignmentData'] = alignment_data
+        high_alignment_data = get_alignment_data(ADEPT_URL, session_id, 'ADEPT-metrics_eval-alignment-target-train-HIGH')
+        low_alignment_data = get_alignment_data(ADEPT_URL, session_id, 'ADEPT-metrics_eval-alignment-target-train-LOW')
+        scenario_results['highAlignmentData'] = high_alignment_data
+        scenario_results['lowAlignmentData'] = low_alignment_data
         scenario_results['serverSessionId'] = session_id
-        print(alignment_data)
+        print(scenario_results['highAlignmentData'])
+        print(scenario_results['lowAlignmentData'])
 
 def get_soartech_alignment(scenario_results, scenario_id):
     url = f"{ST_URL}/api/v1/new_session?user_id=default_user"
@@ -146,10 +149,13 @@ def get_soartech_alignment(scenario_results, scenario_id):
     if start_session.status_code == 201:
         session_id = start_session.json()
         responses = submit_responses(scenario_results, scenario_id, ST_URL, session_id)
-        alignment_data = get_alignment_data(ST_URL, session_id, 'maximization_high')
-        scenario_results['alignmentData'] = alignment_data if alignment_data else None
+        high_alignment_data = get_alignment_data(ST_URL, session_id, 'maximization_high')
+        low_alignment_data = get_alignment_data(ST_URL, session_id, 'maximization_low')
+        scenario_results['highAlignmentData'] = high_alignment_data
+        scenario_results['lowAlignmentData'] = low_alignment_data 
         scenario_results['serverSessionId'] = session_id
-        print(scenario_results['alignmentData'])
+        print(scenario_results['highAlignmentData'])
+        print(scenario_results['lowAlignmentData'])
 
 def load_problem_probes():
     problem_probes_file = os.path.join(CONFIG_PATH, 'problemProbes.json')

--- a/scripts/_0_0_8_add_textbased_alignment.py
+++ b/scripts/_0_0_8_add_textbased_alignment.py
@@ -139,6 +139,8 @@ def get_adept_alignment(scenario_results, scenario_id):
         low_alignment_data = get_alignment_data(ADEPT_URL, session_id, 'ADEPT-metrics_eval-alignment-target-train-LOW')
         scenario_results['highAlignmentData'] = high_alignment_data
         scenario_results['lowAlignmentData'] = low_alignment_data
+        # remove field from previous script that just held HIGH alignment
+        scenario_results['alignmentData'] = None
         scenario_results['serverSessionId'] = session_id
         print(scenario_results['highAlignmentData'])
         print(scenario_results['lowAlignmentData'])
@@ -153,6 +155,8 @@ def get_soartech_alignment(scenario_results, scenario_id):
         low_alignment_data = get_alignment_data(ST_URL, session_id, 'maximization_low')
         scenario_results['highAlignmentData'] = high_alignment_data
         scenario_results['lowAlignmentData'] = low_alignment_data 
+        # remove field from previous script that just held HIGH alignment
+        scenario_results['alignmentData'] = None
         scenario_results['serverSessionId'] = session_id
         print(scenario_results['highAlignmentData'])
         print(scenario_results['lowAlignmentData'])


### PR DESCRIPTION
This attaches highAlignmentData and lowAlignmentData for all of the text-based scenario results. Also clears out the pre-existing 'alignmentData' field from the results. 

Note: This change will break any graphql query pulling alignmentData from mongo documents. That will need to be substituted to pull from these two new fields.