### PR TITLE
Itm 349

### DIFF
--- a/deployment_script.py
+++ b/deployment_script.py
@@ -1,6 +1,5 @@
 from pymongo import MongoClient
 import os
-from scripts._0_0_8_add_textbased_alignment import add_textbased_alignments
 from scripts._0_0_9_add_scenario_names import add_scenario_names
 VERSION_COLLECTION = "itm_version"
 

--- a/deployment_script.py
+++ b/deployment_script.py
@@ -1,10 +1,11 @@
 from pymongo import MongoClient
 import os
 from scripts._0_0_8_add_textbased_alignment import add_textbased_alignments
+from scripts._0_0_9_add_scenario_names import add_scenario_names
 VERSION_COLLECTION = "itm_version"
 
 # Change this version if running a new deploy script
-db_version = "0.0.8"
+db_version = "0.0.9"
 
 
 def check_version(mongoDB):
@@ -33,11 +34,11 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
 
-        add_textbased_alignments(mongoDB)
-
+        #add_textbased_alignments(mongoDB)
+        add_scenario_names(mongoDB)
 
         # Now update db version
-        update_db_version(mongoDB)
+        #update_db_version(mongoDB)
     else:
         print("Script does not need to run on prod, already updated.")
 

--- a/deployment_script.py
+++ b/deployment_script.py
@@ -34,11 +34,10 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
 
-        #add_textbased_alignments(mongoDB)
         add_scenario_names(mongoDB)
 
         # Now update db version
-        #update_db_version(mongoDB)
+        update_db_version(mongoDB)
     else:
         print("Script does not need to run on prod, already updated.")
 

--- a/scripts/_0_0_9_add_scenario_names.py
+++ b/scripts/_0_0_9_add_scenario_names.py
@@ -28,7 +28,7 @@ def add_scenario_names(mongoDB):
             if scenario_index in index_map:
                 page['scenarioName'] = index_map[scenario_index]
                 # add field to existing omnibus results for surveyResults page
-                if scenario_index in (9, 10):
+                if scenario_index in (9, 10) and page.get('pageType') is None:
                     page['pageType'] = 'singleMedic'
                 
 

--- a/scripts/_0_0_9_add_scenario_names.py
+++ b/scripts/_0_0_9_add_scenario_names.py
@@ -27,6 +27,10 @@ def add_scenario_names(mongoDB):
             scenario_index = page['scenarioIndex']
             if scenario_index in index_map:
                 page['scenarioName'] = index_map[scenario_index]
+                # add field to existing omnibus results for surveyResults page
+                if scenario_index in (9, 10):
+                    page['pageType'] = 'singleMedic'
+                
 
         survey_results_collection.update_one(
                 {'_id': result['_id']},

--- a/scripts/_0_0_9_add_scenario_names.py
+++ b/scripts/_0_0_9_add_scenario_names.py
@@ -36,6 +36,7 @@ def add_scenario_names(mongoDB):
                 {'_id': result['_id']},
                 {'$set': result}
             )
+    print("Scenario names added, omnibus pages updated")
 
 
     

--- a/scripts/_0_0_9_add_scenario_names.py
+++ b/scripts/_0_0_9_add_scenario_names.py
@@ -1,0 +1,37 @@
+
+
+def add_scenario_names(mongoDB):
+    survey_results_collection = mongoDB['surveyResults']
+    survey_results = survey_results_collection.find({})
+
+    index_map = {
+        1: 'SoarTech Submarine',
+        2: 'SoarTech Jungle',
+        3: 'SoarTech Desert',
+        4: 'SoarTech Urban',
+        5: 'Adept Submarine',
+        6: 'Adept Jungle',
+        7: 'Adept Desert',
+        8: 'Adept Urban',
+        9: 'SoarTech Omnibus',
+        10: 'Adept Omnibus'
+    }
+
+    for result in survey_results:
+        if ('results' not in result or 'surveyVersion' not in result['results'] or result['results']['surveyVersion'] != 2):
+            continue
+        
+        # all pages with scenarioIndex field
+        pages = [page for page in result['results'].values() if isinstance(page, dict) and 'scenarioIndex' in page]
+        for page in pages:
+            scenario_index = page['scenarioIndex']
+            if scenario_index in index_map:
+                page['scenarioName'] = index_map[scenario_index]
+
+        survey_results_collection.update_one(
+                {'_id': result['_id']},
+                {'$set': result}
+            )
+
+
+    


### PR DESCRIPTION
`python deployment_script.py`

Run this script and then test the survey results page. The page should now have scenario names instead of scenario indexes. I.e Soartech Submarine instead of "scenario 1". Also, omnibus results were only showing the comparison page between two omnibus and not questions for each omnibus separately. There should now be three sections under omnibus survey results, each omnibus individually and then the comparison. 
