### PR TITLE
itm-370

### DIFF
--- a/deployment_script.py
+++ b/deployment_script.py
@@ -3,11 +3,12 @@ from decouple import config
 import os
 from scripts._0_0_9_add_scenario_names import add_scenario_names
 from scripts._0_1_0_fix_participant_id import fix_participant_id
+from scripts._0_1_1_remove_old_textbased_results import remove_old_textbased_results
 
 VERSION_COLLECTION = "itm_version"
 MONGO_URL = config('MONGO_URL')
 # Change this version if running a new deploy script
-db_version = "0.1.0"
+db_version = "0.1.1"
 
 
 def check_version(mongoDB):
@@ -37,6 +38,7 @@ def main():
 
         add_scenario_names(mongoDB)
         fix_participant_id(mongoDB)
+        remove_old_textbased_results(mongoDB)
 
         # Now update db version
         update_db_version(mongoDB)

--- a/scripts/_0_1_1_remove_old_textbased_results.py
+++ b/scripts/_0_1_1_remove_old_textbased_results.py
@@ -1,0 +1,9 @@
+def remove_old_textbased_results(mongoDB):
+    text_scenario_collection = mongoDB['userScenarioResults']
+
+    # only delete data that doesn't have a participantID (all dummy, unused data)
+    text_scenario_collection.delete_many(
+        {"participantID": {"$exists": False}}
+    )
+
+    print("Extraneous textbased results removed.")


### PR DESCRIPTION
https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?assignee=60ba425da547eb00686ee0ce&selectedIssue=ITM-370

A short script that cleans out extraneous data in the text-based results collection. This is all data that didn't have participantID's attached to it and was from testing before the text-based scenarios were complete (all dummy data). None of this data was being pulled to the dashboard so there will be no visual difference there. 