### PR TITLE
ITM-459 data for eval drop downs

### DIFF
--- a/deployment_script.py
+++ b/deployment_script.py
@@ -1,13 +1,13 @@
 from pymongo import MongoClient
 from decouple import config
 import os
-from text_based_scenarios.add_patient_pictures import main as add_pictures
-from text_based_scenarios.convert_yaml_to_json_config import main as generate_textbased_configs
+from scripts._0_1_9_add_evalIDs_to_data import load_data
+
 VERSION_COLLECTION = "itm_version"
 MONGO_URL = config('MONGO_URL')
-# Change this version if running a new deploy script
-db_version = "0.1.8"
 
+# Change this version if running a new deploy script
+db_version = "0.1.9"
 
 def check_version(mongoDB):
     collection = mongoDB[VERSION_COLLECTION]
@@ -16,7 +16,6 @@ def check_version(mongoDB):
         return True 
     # return true if it is a newer db version
     return db_version > version_obj['version']
-
 
 def update_db_version(mongoDB):
     collection = mongoDB[VERSION_COLLECTION]
@@ -27,18 +26,16 @@ def update_db_version(mongoDB):
         version_obj['version'] = db_version
         collection.replace_one({"_id": version_obj["_id"]}, version_obj)
 
-
 def main():
     client = MongoClient(MONGO_URL)
     mongoDB = client['dashboard']
-    if(check_version(mongoDB)):
-        print("New db version, execute scripts")
+    load_data(mongoDB)
+    # if(check_version(mongoDB)):
+    #     print("New db version, execute scripts")
 
-        generate_textbased_configs()
-        add_pictures()
-        update_db_version(mongoDB)
-    else:
-        print("Script does not need to run on prod, already updated.")
+    #     load_data(mongoDB)
+    # else:
+    #     print("Script does not need to run on prod, already updated.")
 
 
 if __name__ == "__main__":

--- a/deployment_script.py
+++ b/deployment_script.py
@@ -29,13 +29,12 @@ def update_db_version(mongoDB):
 def main():
     client = MongoClient(MONGO_URL)
     mongoDB = client['dashboard']
-    load_data(mongoDB)
-    # if(check_version(mongoDB)):
-    #     print("New db version, execute scripts")
+    if(check_version(mongoDB)):
+        print("New db version, execute scripts")
 
-    #     load_data(mongoDB)
-    # else:
-    #     print("Script does not need to run on prod, already updated.")
+        load_data(mongoDB)
+    else:
+        print("Script does not need to run on prod, already updated.")
 
 
 if __name__ == "__main__":

--- a/scripts/_0_1_9_add_evalIDs_to_data.py
+++ b/scripts/_0_1_9_add_evalIDs_to_data.py
@@ -1,0 +1,44 @@
+import os
+import io
+import json
+import yaml
+
+    
+def load_data(mongoDB):
+
+    db_surveyResults = mongoDB["surveyResults"]
+    db_userScenarioResults = mongoDB["userScenarioResults"]
+    db_evaluationIDS = mongoDB["evaluationIDS"]
+
+    result = db_surveyResults.update_many({"evalNumber": None }, { '$set': { "evalNumber": 3 } }) 
+    print(f'Updated {result.modified_count} set evalNumber to 3 in surveyResults')
+
+    result = db_surveyResults.update_many({ "evalName": None }, { '$set': { "evalName": "Metrics Evaluation" } }) 
+    print(f'Updated {result.modified_count} set evalName to "Metrics Evaluation" in surveyResults')
+
+    result = db_userScenarioResults.update_many({ "evalNumber": None }, { '$set': { "evalNumber": 3 } }) 
+    print(f'Updated {result.modified_count} set evalNumber to 3 in userScenarioResults')
+
+    result = db_userScenarioResults.update_many({ "evalName": None }, { '$set': { "evalName": "Metrics Evaluation" } }) 
+    print(f'Updated {result.modified_count} set evalName to "Metrics Evaluation" in surveyuserScenarioResultsResults')
+
+    db_evaluationIDS.insert_one({  
+    "evalNumber": 1,  
+    "evalName": "MVP",  
+    "showMainPage": False})  
+    db_evaluationIDS.insert_one({  
+    "evalNumber": 2,  
+    "evalName": "September Milestone",  
+    "showMainPage": False})  
+    db_evaluationIDS.insert_one({  
+    "evalNumber": 3,  
+    "evalName": "Metrics Evaluation",  
+    "showMainPage": True})  
+    db_evaluationIDS.insert_one({  
+    "evalNumber": 4,  
+    "evalName": "Dry Run Evaluation",  
+    "showMainPage": False})  
+    print("Created evaluationIDS collection and inserted values")
+
+
+


### PR DESCRIPTION
Corresponding dashboard ticket: [dashboard ticket](https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/80l)

This adds evalName and evalNumber to surveyResults and userScenarioResults

This isn't quite idempotent, if this is run some time in the future it may not be correct.
```
db.surveyResults.updateMany({"evalName": null}, { $set: { "evalNumber": 3 } }) 
db.surveyResults.updateMany({"evalName": null}, { $set: { "evalName": "Metrics Evaluation" } }) 
db.userScenarioResults.updateMany({"evalName": null}, { $set: { "evalNumber": 3 } }) 
db.userScenarioResults.updateMany({"evalName": null}, { $set: { "evalName": "Metrics Evaluation" } }) 
```



Also add an evaluationIDS table

```
db.createCollection("evaluationIDS")  
db.evaluationIDS.insertOne({  
  "evalNumber": 1,  
  "evalName": "MVP",  
  "showMainPage": false})  
db.evaluationIDS.insertOne({  
  "evalNumber": 2,  
  "evalName": "September Milestone",  
  "showMainPage": false})  
db.evaluationIDS.insertOne({  
  "evalNumber": 3,  
  "evalName": "Metrics Evaluation",  
  "showMainPage": true})  
db.evaluationIDS.insertOne({  
  "evalNumber": 4,  
  "evalName": "Dry Run Evaluation",  
  "showMainPage": false})  
```
