### PR TITLE
supplies fix

### DIFF
--- a/deployment_script.py
+++ b/deployment_script.py
@@ -5,7 +5,7 @@ VERSION_COLLECTION = "itm_version"
 MONGO_URL = config('MONGO_URL')
 
 # Change this version if running a new deploy script
-db_version = "0.1.11"
+db_version = "0.2.0"
 
 
 def check_version(mongoDB):

--- a/deployment_script.py
+++ b/deployment_script.py
@@ -1,11 +1,11 @@
 from pymongo import MongoClient
 from decouple import config
-from text_based_scenarios._0_1_10_participant_log import main as ingest_participant_log
+from text_based_scenarios.convert_yaml_to_json_config import main as generate_text_based_configs
 VERSION_COLLECTION = "itm_version"
 MONGO_URL = config('MONGO_URL')
 
 # Change this version if running a new deploy script
-db_version = "0.1.10"
+db_version = "0.1.11"
 
 
 def check_version(mongoDB):
@@ -30,7 +30,7 @@ def main():
     mongoDB = client['dashboard']
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
-        ingest_participant_log(mongoDB)
+        generate_text_based_configs()
         update_db_version(mongoDB)
     else:
         print("Script does not need to run on prod, already updated.")

--- a/text_based_scenarios/convert_yaml_to_json_config.py
+++ b/text_based_scenarios/convert_yaml_to_json_config.py
@@ -73,7 +73,7 @@ def partition_doc(scenario, filename):
     scenes = scenario['scenes']
     starting_context = scenario['state']['unstructured']
     starting_mission = scenario['state'].get('mission', {})
-    starting_supplies = scenario['state']['supplies']
+    current_supplies = scenario['state']['supplies']
     initial_characters = scenario['state'].get('characters', [])
     initial_events = scenario['state'].get('events', [])
 
@@ -119,6 +119,8 @@ def partition_doc(scenario, filename):
         return [char for char in all_characters if char['id'] in visible_characters]
 
     def create_page(scene, is_first_scene, transition_info=None):
+        nonlocal current_supplies
+
         page = {
             'name': scene['id'],
             'scenario_id': scenario_id,
@@ -128,7 +130,8 @@ def partition_doc(scenario, filename):
 
         unstructured = get_scene_text(scene, is_first_scene, starting_context)
         processed_unstructured = process_unstructured_text(unstructured)
-        current_supplies = scene.get('state', {}).get('supplies', starting_supplies)
+        if 'supplies' in scene.get('state', {}):
+            current_supplies = scene['state']['supplies']
         
         if transition_info:
             # characters introduced in transition scenes


### PR DESCRIPTION
To test,

`python3 deployment_script.py`

http://localhost:3000/review-text-based

I found a bug earlier today where, after the supplies were updated, that update didn't persist in the Adept scenarios. After the scene where new supplies were introduced, it would revert to the scenario's initial supplies. That should be fixed now. MJ4 and MJ2 have supply updates that should now be properly persisted. 