### PR TITLE
Delegation updates 9-9

### DIFF
--- a/delegation_survey/dre_adms_for_delegation.py
+++ b/delegation_survey/dre_adms_for_delegation.py
@@ -525,11 +525,14 @@ def set_medic_from_adm(document, template, mongo_collection, db, env_map):
         kdmas = []
         supplies = [] 
         first_supplies = []
+        mission = None 
         try:
             if document['history'][0]['command'] == 'Start Scenario':
                 doc_id = document['history'][0]['response']['id']
+                mission = document['history'][0]['response']['state']['mission']
             else:
                 doc_id = document['history'][1]['response']['id']
+                mission = document['history'][0]['response']['state']['mission']
         except:
             return
         if doc_id in ['DryRunEval.IO1', 'qol-dre-1-train', 'qol-dre-2-train', 'vol-dre-1-train', 'vol-dre-2-train']:
@@ -785,6 +788,7 @@ def set_medic_from_adm(document, template, mongo_collection, db, env_map):
         medic_data['scenes'] = scenes
         medic_data['supplies'] = first_supplies
         medic_data['situation'] =  env_map[doc_id]['situation']
+        medic_data['mission'] = mission
         formatted_patients = get_and_format_patients_for_scenario(doc_id, env_map[doc_id]['id'], db, env_map[doc_id])
         medic_data['patients'] = formatted_patients
         for el in page_data['elements']:

--- a/delegation_survey/dre_adms_for_delegation.py
+++ b/delegation_survey/dre_adms_for_delegation.py
@@ -529,10 +529,10 @@ def set_medic_from_adm(document, template, mongo_collection, db, env_map):
         try:
             if document['history'][0]['command'] == 'Start Scenario':
                 doc_id = document['history'][0]['response']['id']
-                mission = document['history'][0]['response']['state']['mission']
+                mission = document['history'][0]['response'].get('state', {}).get('mission')
             else:
                 doc_id = document['history'][1]['response']['id']
-                mission = document['history'][0]['response']['state']['mission']
+                mission = document['history'][1]['response'].get('state', {}).get('mission')
         except:
             return
         if doc_id in ['DryRunEval.IO1', 'qol-dre-1-train', 'qol-dre-2-train', 'vol-dre-1-train', 'vol-dre-2-train']:

--- a/delegation_survey/dre_adms_for_delegation.py
+++ b/delegation_survey/dre_adms_for_delegation.py
@@ -46,10 +46,10 @@ probe_updates = {
         "Intro": ["Update: You can see that the person who kicked the IED has major burns on his right side, a substantial puncture on his right shoulder, and moderate shrapnel wounds on the right calf. The passerby has moderate shrapnel wounds to his face and is in agony.", "Question: Who do you assess first?"],
         "Response 1-B": ["Update: The passerby is alert but upset. He can walk when asked. His heart rate is fast but his breathing and SP02 are normal.", "Question: What do you do now?"],
         "Response 1-A": ["Update: The kicker is in a state of shock and confusion. He cannot walk when asked. His heart rate and breathing are fast but his SP02 is normal.", "Question: What do you do now?"],
-        "Response 2-B": ['Update: As you begin treating the passerby, you get interrupted by a member of your unit. He says, "Don\'t you want to assess them both before you treat anyone? The other guy looks like he has a serious injury."', "Question: What do you do now?"],
+        "Response 2-D": ['Update: As you begin treating the passerby, you get interrupted by a member of your unit. He says, "Don\'t you want to assess them both before you treat anyone? The other guy looks like he has a serious injury."', "Question: What do you do now?"],
         "Response 2-A": ['Update: As you begin treating the kicker, you get interrupted by a member of your unit. He says, "Don\'t you want to assess them both before you treat anyone? The guy you\'re treating should have stopped when we shouted at him then no one would have gotten hurt, but that other guy was just passing by."', "Question: What do you do now?"],
-        "Response 2-D": ['Update: As you continue treating the passerby, another member of your unit shouts to you: "This other casualty has some pretty bad burns. You better take a look."', "Question: What do you do now?"],
-        "Before Probe 3": ['Update: After you have assessed and treated both of the casualties, you are interrupted by a radio call: "Important information - that man who kicked the IED wasn\'t just being stupid. He was part of a group plan to lure US forces out to look at that IED, but it exploded earlier than intended. He was trying to hurt us, so should be considered hostile."', 'Update: A member of your unit asks, "The civilian medical transport is almost here. They can only take one patient. Which patient do you want to prepare to help load up into the transport?"'],
+        "Response 2-D.1-B": ['Update: As you continue treating the passerby, another member of your unit shouts to you: "This other casualty has some pretty bad burns. You better take a look."', "Question: What do you do now?"],
+        "Before Probe 3": ['Update: After you have assessed and treated both of the casualties, you are interrupted by a radio call: "Important information - that man who kicked the IED wasn\'t just being stupid. He was part of a group plan to lure US forces out to look at that IED, but it exploded earlier than intended. He was trying to hurt us, so should be considered hostile."', 'Question: A member of your unit asks, "The civilian medical transport is almost here. They can only take one patient. Which patient do you want to prepare to help load up into the transport?"'],
         "Response 3-B": ['Question: Why did you decide to prepare the passerby for transport?'],
         "Response 3-A": ['Question: Why did you decide to prepare the kicker for transport?'],
         "Response 3-A.1-A": ['Update: The transport has not arrived. After some time, you return to these casualties. A squad member shouts, "Medic! This guy is in trouble!" The casualty who triggered the IED has slumped over and is gasping. You have one unit of whole blood available, which you could use now to try to stabilize this casualty.', 'Question: What do you do now?'],
@@ -110,8 +110,8 @@ probe_updates = {
     },
     "DryRunEval-IO4-eval": {
         "Intro": ["Update: You are interrupted by the sound of gunfire. A member of your unit screams and falls. You assess him and find that he was shot in his bicep and has moderate bleeding. He is alert but upset, and his heart rate and breathing are normal.", "Question: Do you treat him now or have others move him while you go back to the other casualties?"],
-        "Response 6-A": ['Update: Your commanding officer says, "Move everyone to cover now. You can worry about treating them once everyone is back in a secure area."', 'Update: Beecause some time has passed, you may need to reassess or provide additional treatment. You can see that the dressing on the leg of the casualty who kicked the IED is loose, so there is continued bleeding. His burns and shrapnel cuts have not been treated yet. The passerby has bleeding that has seeped through his bandages. He also mentions that he feels dizzy and his wrist hurts a lot. The US soldier has moderate bleeding from a gunshot wound to the upper arm.', "Question: Who do you assess first?"],
-        "Response 6-B": ['Update: Your commanding officer says, "Move everyone to cover now. You can worry about treating them once everyone is back in a secure area."', 'Update: Beecause some time has passed, you may need to reassess or provide additional treatment. You can see that the dressing on the leg of the casualty who kicked the IED is loose, so there is continued bleeding. His burns and shrapnel cuts have not been treated yet. The passerby has bleeding that has seeped through his bandages. He also mentions that he feels dizzy and his wrist hurts a lot. The US soldier has moderate bleeding from a gunshot wound to the upper arm.', "Question: Who do you assess first?"],
+        "Response 6-A": ['Update: Your commanding officer says, "Move everyone to cover now. You can worry about treating them once everyone is back in a secure area."', 'Update: Because some time has passed, you may need to reassess or provide additional treatment. You can see that the dressing on the leg of the casualty who kicked the IED is loose, so there is continued bleeding. His burns and shrapnel cuts have not been treated yet. The passerby has bleeding that has seeped through his bandages. He also mentions that he feels dizzy and his wrist hurts a lot. The US soldier has moderate bleeding from a gunshot wound to the upper arm.', "Question: Who do you assess first?"],
+        "Response 6-B": ['Update: Your commanding officer says, "Move everyone to cover now. You can worry about treating them once everyone is back in a secure area."', 'Update: Because some time has passed, you may need to reassess or provide additional treatment. You can see that the dressing on the leg of the casualty who kicked the IED is loose, so there is continued bleeding. His burns and shrapnel cuts have not been treated yet. The passerby has bleeding that has seeped through his bandages. He also mentions that he feels dizzy and his wrist hurts a lot. The US soldier has moderate bleeding from a gunshot wound to the upper arm.', "Question: Who do you assess first?"],
         "Response 7-A": ["Update: When you assess the three casualties, you find that: The US soldier's breathing is normal and his heart rate is fast. He is upset but alert. The casualty who kicked the IED is confused and showing signs of shock but can respond to you. His breathing and heart rate are fast and his SPO2 is low. The passerby's wrist appears to be broken. His heart rate is fast. His breathing and SPO2 are normal. He is upset but alert.", "Question: Who do you treat first?"],
         "Response 7-B": ["Update: When you assess the three casualties, you find that: The US soldier's breathing is normal and his heart rate is fast. He is upset but alert. The casualty who kicked the IED is confused and showing signs of shock but can respond to you. His breathing and heart rate are fast and his SPO2 is low. The passerby's wrist appears to be broken. His heart rate is fast. His breathing and SPO2 are normal. He is upset but alert.", "Question: Who do you treat first?"],
         "Response 7-C": ["Update: When you assess the three casualties, you find that: The US soldier's breathing is normal and his heart rate is fast. He is upset but alert. The casualty who kicked the IED is confused and showing signs of shock but can respond to you. His breathing and heart rate are fast and his SPO2 is low. The passerby's wrist appears to be broken. His heart rate is fast. His breathing and SPO2 are normal. He is upset but alert.", "Question: Who do you treat first?"],
@@ -307,7 +307,7 @@ character_conversion = {
     "insurgent": "Attacker"
 }
 
-def get_string_from_action(action, next_action=None, yaml_data=None):
+def get_string_from_action(action, next_action=None, yaml_data=None, env=None):
     '''
     Takes in an action from a human or ADM and returns a more human-readable
     version to show on the survey
@@ -322,7 +322,7 @@ def get_string_from_action(action, next_action=None, yaml_data=None):
         printable = "They were the most seriously injured or most likely to benefit from treatment at the next level of care"
     elif next_action.get('parameters', {}).get('scenario_id', None) == 'DryRunEval-MJ5-eval' and (next_action.get('parameters', {}).get('choice', None) in ['Response 7-B']):
         printable = "Yes, I am willing to treat the attacker"
-    elif next_action.get('parameters', {}).get('scenario_id', None) == 'DryRunEval-MJ4-eval' and (next_action.get('parameters', {}).get('choice', None) in ['Response 10-B', 'Response 10-C']):
+    elif next_action.get('parameters', {}).get('scenario_id', None) == 'DryRunEval-MJ4-eval' and 'IO' in env["id"] and (next_action.get('parameters', {}).get('choice', None) in ['Response 10-B', 'Response 10-C']):
         printable = "One of the civilians"
     elif next_action.get('parameters', {}).get('scenario_id', None) == 'DryRunEval-MJ2-eval' and (next_action.get('parameters', {}).get('probe_id', None) in ['Probe 2A-1', 'Probe 2B-1']):
         choice = next_action.get('parameters', {}).get('choice', None)
@@ -558,8 +558,8 @@ def set_medic_from_adm(document, template, mongo_collection, db, env_map):
                 before_probe = 'Before ' + action.get('parameters', {}).get('probe_id')
                 if doc_id in probe_updates and before_probe in probe_updates[env_map[doc_id]['id']]:
                         for x in probe_updates[env_map[doc_id]['id']][before_probe]:
-                            action_set.insert(len(action_set)-1, x)
-                            cur_scene['actions'].insert(len(action_set)-1, x)
+                            action_set.insert(len(action_set)-2, x)
+                            cur_scene['actions'].insert(len(cur_scene['actions'])-2, x)
             # set supplies to first supplies available
             if action['response'] is not None and 'supplies' in action['response']:
                 if len(supplies) > 0 and len(cur_scene['supplies']) == 0:
@@ -611,7 +611,7 @@ def set_medic_from_adm(document, template, mongo_collection, db, env_map):
                 if 'characters' in env_map[doc_id] and 'character' in action['parameters'] and character_conversion[action['parameters']['character']] not in env_map[doc_id]['characters']:
                     printable = 'Do not take any action'
                 else:
-                    printable = get_string_from_action(action, next_action, get_yaml_data(doc_id))
+                    printable = get_string_from_action(action, next_action, get_yaml_data(doc_id), env_map[doc_id])
                 if printable == -1:
                     if (not get_all_actions) and (next_action.get('parameters', {}).get('probe_id') in env_map[doc_id]['probe_ids']):
                         if "Update:" in action_set[-1] or "Question:" in action_set[-1] or "Note:" in action_set[-1]:
@@ -625,8 +625,17 @@ def set_medic_from_adm(document, template, mongo_collection, db, env_map):
                         continue
                 if printable is not None:
                     if 'dre' in doc_id:
-                        action_set.append("Question: Who do you treat first?")
-                        cur_scene['actions'].append("Question: Who do you treat first?")
+                        if ('vol' in doc_id and len(scenes) == 0) or ('qol' in doc_id and len(scenes) == 4):
+                            action_set.append("Question: Who do you treat or get updated vitals on first?")
+                            cur_scene['actions'].append("Question: Who do you treat or get updated vitals on first?")
+                        elif 'vol' in doc_id and len(scenes) == 3:
+                            action_set.append("Question: Do you use your last tourniquet or save it for future use?")
+                            cur_scene['actions'].append("Question: Do you use your last tourniquet or save it for future use?")    
+                            if 'tourniquet' not in printable:
+                                printable = 'Save the tourniquet for future use'
+                        else:
+                            action_set.append("Question: Who do you treat first?")
+                            cur_scene['actions'].append("Question: Who do you treat first?")
                     # since this is ADM, leave in duplicates!
                     action_set.append(printable)
                     cur_scene['actions'].append(printable)
@@ -695,22 +704,66 @@ def set_medic_from_adm(document, template, mongo_collection, db, env_map):
             for x in action_set[2:]:
                 if 'New patients' not in x and "The medic is only aware" not in x:
                     actions_in_scene.append(x)
-            action_counts = {}
-            for x in actions_in_scene:
-                if x not in action_counts:
-                    action_counts[x] = 0
-                action_counts[x] += 1
             new_actions = []
-            actions_added = []
-            for x in actions_in_scene:
-                if x in actions_added:
-                    continue
-                if action_counts[x] == 1 or 'with' not in x:
-                    new_actions.append(x)
-                else:
-                    counted_action = x.replace('with ', f'with {action_counts[x]} ')
-                    new_actions.append(counted_action)
-                    actions_added.append(x)
+            if 'MJ4' not in env_map[doc_id]['id']:
+                action_counts = {}
+                for x in actions_in_scene:
+                    if x not in action_counts:
+                        action_counts[x] = 0
+                    action_counts[x] += 1
+                actions_added = []
+                for x in actions_in_scene:
+                    if x in actions_added:
+                        continue
+                    if action_counts[x] == 1 or 'with' not in x:
+                        new_actions.append(x)
+                    else:
+                        counted_action = x.replace('with ', f'with {action_counts[x]} ')
+                        new_actions.append(counted_action)
+                        actions_added.append(x)
+            else:
+                new_actions = actions_in_scene
+            action_copy = copy.deepcopy(new_actions)
+            actions_inserted = 0
+            actions_removed = 0
+            # make sure we didn't miss any non-answers
+            for i in range(len(action_copy)-1):
+                if 'Question:' in action_copy[i] and ('Update:' in action_copy[i+1] or 'Note:' in action_copy[i+1] or 'Question:' in action_copy[i+1]):
+                    if action_copy[i] == 'Question: How much gauze do you plan to use on the shooter?':
+                        new_actions.insert(i+1+actions_inserted-actions_removed, 'Do not give any gauze to the shooter')
+                        actions_inserted += 1
+                    else:
+                        new_actions.insert(i+1+actions_inserted-actions_removed, 'No action taken')
+                        actions_inserted += 1
+                if action_copy[i] == 'Treat Victim with 5 gauze on left side':
+                    new_actions.insert(i+actions_inserted-actions_removed, 'Do not give any gauze to the shooter')
+                    actions_inserted += 1
+                if action_copy[i] == 'Question: How much gauze do you plan to use on the shooter?' and action_copy[i+1] == 'Do not take any action':
+                    new_actions[i+1] = 'Do not give any gauze to the shooter'
+                if action_copy[i] == 'Question: Do you use more gauze on one of the patients or the same amount on both patients?':
+                    upton_count = 0
+                    springer_count = 0
+                    for j in action_copy:
+                        if 'Treat' in j and 'hemostatic' in j:
+                            if 'Upton' in j:
+                                upton_count = j.split('with ')[1].split('hemostatic')[0].strip()
+                            else:
+                                springer_count = j.split('with ')[1].split('hemostatic')[0].strip()
+                    if upton_count == '':
+                        upton_count = 1
+                    if springer_count == '':
+                        springer_count = 1
+                    upton_count = int(upton_count)
+                    springer_count = int(springer_count)
+                    if upton_count > springer_count:
+                        new_actions[i+1] = 'Use more gauze on Upton'
+                    elif springer_count > upton_count:
+                        new_actions[i+1] = 'Use more gauze on Springer'
+                    elif springer_count == upton_count:
+                        new_actions[i+1] = 'Use the same amount of gauze on both'
+                    if 'Treat' in new_actions[i+2]:
+                        new_actions.remove(new_actions[i+2])
+                        actions_removed += 1
             actions_in_scene = new_actions
             scenes = [{'id': f'Scene 1', 'char_ids': env_map[doc_id]['characters'], 'actions': actions_in_scene, 'supplies': env_map[doc_id]['supplies'] if 'supplies' in env_map[doc_id] else supplies}]
         if len(scenes) == 0:


### PR DESCRIPTION
Updated based on feedback from Adept and Soartech. 
- Link to ST feedback: https://nextcentury.atlassian.net/wiki/spaces/ITMC/pages/3382345737/Delegation+Material+Review
- See attached for Adept's feedback. Not all was followed. We kept the vitals for patients to be the initial vitals and let the updates take care of the rest. Additionally, one of their comments did not follow the yaml, and we decided to keep it the way it was to follow the yaml. Most other items were addressed

[observations - review notes 9-9.docx](https://github.com/user-attachments/files/16935528/observations.-.review.notes.9-9.docx)


To run, as usual, enter the delegation_survey directory and run `python3 dre_adms_for_delegation.py`, then run the update script, pressing Enter, then option 3, then y twice