### PR TITLE
Final dre changes

### DIFF
--- a/delegation_survey/dre_adms_for_delegation.py
+++ b/delegation_survey/dre_adms_for_delegation.py
@@ -782,8 +782,8 @@ def set_medic_from_adm(document, template, mongo_collection, db, env_map):
         page_data['admSession'] = meta['session_id']
         medic_data = page_data['elements'][0]
         medic_data['dmName'] = name
-        medic_data['title'] = env_map[doc_id]['name'].replace('SoarTech', 'ST') + ' Scenario: ' + name
-        medic_data['name'] = medic_data['title']
+        medic_data['name'] = env_map[doc_id]['name'].replace('SoarTech', 'ST') + ' Scenario: ' + name
+        medic_data['title'] = " "
         medic_data['actions'] = action_set[2:action_set.index('SCENE CHANGE') if 'SCENE CHANGE' in action_set else len(action_set)]
         medic_data['scenes'] = scenes
         medic_data['supplies'] = first_supplies

--- a/delegation_survey/survey-configs/postScenario.json
+++ b/delegation_survey/survey-configs/postScenario.json
@@ -53,11 +53,11 @@
                     "name": "I had enough information in this presentation to make the ratings for the questions asked on the previous pages about the DMs",
                     "title": "I had enough information in this presentation to make the ratings for the questions asked on the previous pages about the DMs",
                     "choices": [
-                        "Strongly disagree",
-                        "Disagree",
-                        "Neither agree nor disagree",
-                        "Agree",
-                        "Strongly agree"
+                        "Way too much",
+                        "Too much",
+                        "Just right",
+                        "Too Little",
+                        "Way too little"
                     ],
                     "isRequired": true
                 },

--- a/deployment_script.py
+++ b/deployment_script.py
@@ -1,11 +1,11 @@
 from pymongo import MongoClient
 from decouple import config
-from scripts._0_2_1_dre_remove_duplicates import dre_remove_duplicates
+from text_based_scenarios.convert_yaml_to_json_config import main as generate_textbased_configs
 VERSION_COLLECTION = "itm_version"
 MONGO_URL = config('MONGO_URL')
 
 # Change this version if running a new deploy script
-db_version = "0.2.1"
+db_version = "0.2.2"
 
 
 def check_version(mongoDB):
@@ -31,7 +31,7 @@ def main():
     mongoDB = client['dashboard']
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
-        dre_remove_duplicates(mongoDB)
+        generate_textbased_configs()
         update_db_version(mongoDB)
     else:
         print("Script does not need to run on prod, already updated.")

--- a/text_based_scenarios/convert_yaml_to_json_config.py
+++ b/text_based_scenarios/convert_yaml_to_json_config.py
@@ -173,7 +173,7 @@ def partition_doc(scenario, filename):
 
         template_element = {
             'name': 'template ' + str(page['name']),
-            'title': str(page['name']),
+            'title': " ",
             'type': 'medicalScenario',
             'unstructured': processed_unstructured,
             'supplies': current_supplies,


### PR DESCRIPTION
Run `python3 deployment_script.py` from root of directory.

Then 
`cd delegation_survey`
`python3 dre_adms_for_delegation.py`
`python3 update_survey.py`
`enter`
`3`
`y`
`y`

Text based scenarios should no longer have titles on the page like "probe 2.1"
Same goes for delegation survey no longer having scenario names displayed to participants
Question in post scenario measures page had answer key change