### PR TITLE
remove some probes from adept training scenarios

### DIFF
--- a/deployment_script.py
+++ b/deployment_script.py
@@ -1,11 +1,11 @@
 from pymongo import MongoClient
 from decouple import config
-from text_based_scenarios.convert_yaml_to_json_config import main as generate_textbased_configs
+from text_based_scenarios._0_2_3_adept_remove_probes import remove_adept_probes
 VERSION_COLLECTION = "itm_version"
 MONGO_URL = config('MONGO_URL')
 
 # Change this version if running a new deploy script
-db_version = "0.2.2"
+db_version = "0.2.3"
 
 
 def check_version(mongoDB):
@@ -14,7 +14,6 @@ def check_version(mongoDB):
     if version_obj is None:
         return True 
     # return true if it is a newer db version
-    print(version_obj['version'])
     return db_version > version_obj['version']
 
 def update_db_version(mongoDB):
@@ -31,7 +30,7 @@ def main():
     mongoDB = client['dashboard']
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
-        generate_textbased_configs()
+        remove_adept_probes(mongoDB)
         update_db_version(mongoDB)
     else:
         print("Script does not need to run on prod, already updated.")

--- a/text_based_scenarios/_0_2_3_adept_remove_probes.py
+++ b/text_based_scenarios/_0_2_3_adept_remove_probes.py
@@ -1,0 +1,38 @@
+def remove_adept_probes(mongo_db):
+    text_config_collection = mongo_db['textBasedConfig']
+    
+    dry_run_eval_io1 = text_config_collection.find_one({"scenario_id": "DryRunEval.IO1"})
+    dry_run_eval_mj1 = text_config_collection.find_one({"scenario_id": "DryRunEval.MJ1"})
+    
+    io1_pages_to_drop = ["P2", "P3", "P4", "P8", "P9", "P10", "P13", "P14"]
+    mj1_pages_to_drop = ["P1", "P2", "P3", "P4", "P14", "P15", "P16"]
+    
+    if dry_run_eval_io1 and 'pages' in dry_run_eval_io1:
+        original_pages = len(dry_run_eval_io1['pages'])
+        dry_run_eval_io1['pages'] = [page for page in dry_run_eval_io1['pages'] if page.get('name') not in io1_pages_to_drop]
+        remaining_pages = len(dry_run_eval_io1['pages'])
+        
+        text_config_collection.update_one(
+            {"scenario_id": "DryRunEval.IO1"},
+            {"$set": {"pages": dry_run_eval_io1['pages']}}
+        )
+        
+        print(f"DryRunEval.IO1: Dropped {original_pages - remaining_pages} pages.")
+        print(f"Pages dropped: {', '.join(io1_pages_to_drop)}")
+    else:
+        print("DryRunEval.IO1: Document not found or 'pages' field missing.")
+    
+    if dry_run_eval_mj1 and 'pages' in dry_run_eval_mj1:
+        original_pages = len(dry_run_eval_mj1['pages'])
+        dry_run_eval_mj1['pages'] = [page for page in dry_run_eval_mj1['pages'] if page.get('name') not in mj1_pages_to_drop]
+        remaining_pages = len(dry_run_eval_mj1['pages'])
+        
+        text_config_collection.update_one(
+            {"scenario_id": "DryRunEval.MJ1"},
+            {"$set": {"pages": dry_run_eval_mj1['pages']}}
+        )
+        
+        print(f"DryRunEval.MJ1: Dropped {original_pages - remaining_pages} pages.")
+        print(f"Pages dropped: {', '.join(mj1_pages_to_drop)}")
+    else:
+        print("DryRunEval.MJ1: Document not found or 'pages' field missing.")


### PR DESCRIPTION
`python3 deployment_script.py`

This script will remove some probes from the adept training scenarios. After running ingest, IO1 should have 8 pages and MJ1 should have 9 pages. Run through the text-based scenario once and verify that we are still getting alignment scores for those two training scenarios by viewing the `alignmentData` field attached to the mongo documents