### PR TITLE
updated duplicate page name so data will get stored

### DIFF
--- a/delegation_survey/update_survey_config.py
+++ b/delegation_survey/update_survey_config.py
@@ -1205,7 +1205,7 @@ def version4_setup():
     tool.add_page_by_json(warning_page)
 
     exp_page_2 = {
-            "name": "Participant ID Page",
+            "name": "VR Page",
             "elements": [
                 {
                     "type": "radiogroup",


### PR DESCRIPTION
Rerun update_survey_config with 3 y y 

Test in the dashboard that the second page gets stored