### PR TITLE
Participant Log Update

### DIFF
--- a/dre_probe_matcher.py
+++ b/dre_probe_matcher.py
@@ -581,13 +581,17 @@ class ProbeMatcher:
         evaced = get_evaced_patients()
 
         patients_in_order = ['US Soldier 1', 'Civilian 1', 'Attacker 1', 'US Soldier 2', 'US Soldier 3', 'Attacker 2', 'US Soldier 4', 'Civilian 2']
+        clean_patient_order_engaged = []
+        for x in patient_order_engaged:
+            if x not in clean_patient_order_engaged:
+                clean_patient_order_engaged.append(x)
         for i in range(len(patients_in_order)):
             name = f'Patient {i+1}'
             sim_name = patients_in_order[i]
             triage_time = triage_times['interactions'].get(sim_name, 0)
             results[f'{name}_time'] = triage_time
             try:
-                results[f'{name}_order'] = patient_order_engaged.index(sim_name) + 1
+                results[f'{name}_order'] = clean_patient_order_engaged.index(sim_name) + 1
             except:
                 results[f'{name}_order'] = 'N/A'
             results[f'{name}_evac'] = 'Yes' if sim_name in evaced else 'No'

--- a/scripts/_0_3_2_update_participant_log.py
+++ b/scripts/_0_3_2_update_participant_log.py
@@ -1,0 +1,20 @@
+def fix_participant_id(mongoDB):
+    participant_log = mongoDB['participantLog']
+    text_scenario_collection = mongoDB['userScenarioResults']
+    survey_collection = mongoDB['surveyResults']
+    sim_collection = mongoDB['humanSimulatorRaw']
+
+    participants = participant_log.find()
+
+    for participant in participants:
+        pid = participant['ParticipantID']
+        text_found = text_scenario_collection.count_documents({"participantID": str(pid)})
+        surveys_found = survey_collection.count_documents({"results.Participant ID Page.questions.Participant ID.response": str(pid)})
+        sim_found = sim_collection.count_documents({"pid": str(pid)})
+        participant_log.update_one(
+            {"ParticipantID": pid},
+            {"$set": {"claimed": text_found > 0 or surveys_found > 0 or sim_found > 0, "textEntryCount": text_found, 
+                      "surveyEntryCount": surveys_found, "simEntryCount": sim_found}}
+        )
+
+    print("Updated the participant log to track used ids.")


### PR DESCRIPTION
For the new text scenario login page, we will need a way to see which participant ids have been claimed already in order to avoid race conditions and duplicate PIDs. This script updates the current participantLog with 4 new attributes:

1. claimed - a boolean that will simply track if this PID is already attached to a user.
2. textEntryCount - a number showing how many entries are in the userScenarioResults collection for this participant
3. surveyEntryCount - a number showing how many entries are in the surveyResults collection for this participant
4. simEntryCount - a number showing how many entries are in the humanSimulatorRaw collection for this participant

Parts of the dashboard and probe matcher will need to be updated to keep these variables up to date, but this will retroactively add this data to the participantLog collection 