### PR TITLE
script for fixing 20240913

### DIFF
--- a/scripts/_0_3_3_fix_202409113.py
+++ b/scripts/_0_3_3_fix_202409113.py
@@ -1,0 +1,28 @@
+def fix_pid(mongo_db):
+    text_scenario_results = mongo_db['userScenarioResults']
+
+    documents = list(text_scenario_results.find(
+        {"participantID": "202409113"}
+    ).sort("startTime", 1))  
+    
+    unique_times = sorted(set(doc["startTime"] for doc in documents))
+    if len(unique_times) != 2:
+        print(f"Warning: Found {len(unique_times)} unique start times instead of expected 2")
+        return
+        
+    text_scenario_results.update_many(
+        {
+            "participantID": "202409113",
+            "startTime": unique_times[0]
+        },
+        {"$set": {"participantID": "202409113A"}}
+    )
+    
+    text_scenario_results.update_many(
+        {
+            "participantID": "202409113",
+            "startTime": unique_times[1]
+        },
+        {"$set": {"participantID": "202409113B"}}
+    )
+    

--- a/scripts/_0_3_3_fix_202409113.py
+++ b/scripts/_0_3_3_fix_202409113.py
@@ -6,23 +6,42 @@ def fix_pid(mongo_db):
     ).sort("startTime", 1))  
     
     unique_times = sorted(set(doc["startTime"] for doc in documents))
-    if len(unique_times) != 2:
-        print(f"Warning: Found {len(unique_times)} unique start times instead of expected 2")
-        return
+    if len(unique_times) == 2:
+        text_scenario_results.update_many(
+            {
+                "participantID": "202409113",
+                "startTime": unique_times[0]
+            },
+            {"$set": {"participantID": "202409113A"}}
+        )
         
-    text_scenario_results.update_many(
-        {
-            "participantID": "202409113",
-            "startTime": unique_times[0]
-        },
-        {"$set": {"participantID": "202409113A"}}
-    )
+        text_scenario_results.update_many(
+            {
+                "participantID": "202409113",
+                "startTime": unique_times[1]
+            },
+            {"$set": {"participantID": "202409113B"}}
+        )
+
+    participant_log = mongo_db['participantLog']
     
-    text_scenario_results.update_many(
-        {
-            "participantID": "202409113",
-            "startTime": unique_times[1]
-        },
-        {"$set": {"participantID": "202409113B"}}
-    )
+    original_entry = participant_log.find_one({"ParticipantID": 202409113})
     
+    if original_entry:
+        entry_a = original_entry.copy()
+        entry_b = original_entry.copy()
+        
+        entry_a["ParticipantID"] = "202409113A"
+        entry_a["textEntryCount"] = 5
+        entry_b["ParticipantID"] = "202409113B"
+        entry_b["textEntryCount"] = 5
+        
+        entry_a.pop('_id', None)
+        entry_b.pop('_id', None)
+        
+        participant_log.insert_one(entry_a)
+        participant_log.insert_one(entry_b)
+        
+        participant_log.delete_one({"ParticipantID": 202409113})
+    else:
+        print("Warning: Original participant log entry not found")


### PR DESCRIPTION
`python3 deployment_script.py`

pid 20240913 was entered twice for two different participants. This script groups them based on their start time so they can be distinguished from each other in the dashboard. After running the script, instead of 10 documents in `userScenarioResults` with pid `20240913`, there should be 5 with `20240913A` and a start time of `Tue Oct 01 2024 15:11:25 GMT-0400 (Eastern Daylight Time)` and 5 documents with `20240913B` and a start time of `Tue Oct 01 2024 15:34:46 GMT-0400 (Eastern Daylight Time)`. You should be able to view this change reflected on the participant view of http://localhost:3000/text-based-results for IO2, MJ1, and MJ2 scenarios