### PR TITLE
Itm 681 persist ta1 dre

### DIFF
--- a/.env
+++ b/.env
@@ -5,21 +5,31 @@ LOG_LEVEL=2
 # location to access mongo database
 MONGO_URL="mongodb://simplemongousername:simplemongopassword@localhost:27030/?authSource=dashboard"
 
-# location of soartech server
-# development
-# ST_URL="http://127.0.0.1:8084"
-# production outside AWS
-ST_URL="https://darpaitm.caci.com/soartech/"
-# production inside AWS
-# ST_URL="http://10.216.38.125:8084"
+# SOARTECH
+## local development with local instance of SoarTech
+# ST_URL="http://127.0.0.1:8084/"
+# ST_DRE_URL="http://127.0.0.1:8086/"
 
-# location of adept server
- # development
-# ADEPT_URL="http://127.0.0.1:8080"
-# production outside AWS
+## Production SoarTech use when outside of AWS
+ST_URL="https://darpaitm.caci.com/soartech/"
+ST_DRE_URL="https://darpaitm.caci.com/soartech_dre/"
+
+## Production SoarTech inside AWS
+# ST_URL="http://10.216.38.25:8084/"
+# ST_DRE_URL="http://10.216.38.25:8086/"
+
+# ADEPT
+## local development with local instance of ADEPT
+# ADEPT_URL="http://127.0.0.1:8080/"
+# ADEPT_DRE_URL="http://127.0.0.1:8087/"
+
+## Production Adept, use when outside of AWS
 ADEPT_URL="https://darpaitm.caci.com/adept/"
-# production inside AWS
+ADEPT_DRE_URL="https://darpaitm.caci.com/adept_dre/"
+
+## Production Adept, use when inside of AWS
 # ADEPT_URL="http://10.216.38.101:8080/"
+# ADEPT_DRE_URL="http://10.216.38.101:8087/"
 
 # adept target id
 ADEPT_TARGET="ADEPT-metrics_eval-alignment-target-train-HIGH"

--- a/dre_probe_matcher.py
+++ b/dre_probe_matcher.py
@@ -16,8 +16,8 @@ RERUN_ADEPT_SESSIONS = False # rerun adept sessions only to get new session ids
 EVAL_NUM = 4
 EVAL_NAME = 'Dry Run Evaluation'
 
-ADEPT_URL = "https://darpaitm.caci.com/adept/" # config("ADEPT_URL")
-ST_URL = "https://darpaitm.caci.com/soartech/" # config("ST_URL")
+ADEPT_URL = config("ADEPT_DRE_URL")
+ST_URL = config("ST_DRE_URL")
 
 SCENE_MAP = {
     "qol-dre-1-eval Narrative": "dryrun-soartech-eval-qol1.yaml",
@@ -729,10 +729,10 @@ class ProbeMatcher:
                         'vol-human-5032922-SplitLowMulti', 'qol-human-0000001-SplitEvenMulti', 'vol-synth-LowExtreme', 'qol-human-8022671-SplitLowMulti', 'vol-synth-HighExtreme', 
                         'qol-human-5032922-SplitLowMulti', 'vol-synth-HighCluster', 'qol-synth-LowExtreme', 'vol-synth-LowCluster', 'qol-synth-HighExtreme', 'vol-synth-SplitLowBinary', 
                         'qol-synth-HighCluster', 'qol-synth-LowCluster', 'qol-synth-SplitLowBinary']
-                self.send_probes(f'{ST_URL}/api/v1/response', match_data, self.soartech_sid, self.soartech_yaml['id'])
+                self.send_probes(f'{ST_URL}api/v1/response', match_data, self.soartech_sid, self.soartech_yaml['id'])
                 # send fake probes for 3 entries that are missing data. These probes will not be used to calculate alignment!
                 if self.participantId == '202409111' and 'vol' in self.environment:
-                    self.send_probes(f'{ST_URL}/api/v1/response', 
+                    self.send_probes(f'{ST_URL}api/v1/response', 
                         [
                             { 
                                 "scene_id": 'id-10', 
@@ -750,7 +750,7 @@ class ProbeMatcher:
                             }
                         ], self.soartech_sid, self.soartech_yaml['id'])
                 if self.participantId == '202409112' and 'qol' in self.environment:
-                    self.send_probes(f'{ST_URL}/api/v1/response', 
+                    self.send_probes(f'{ST_URL}api/v1/response', 
                         [
                             { 
                                 "scene_id": 'id-11',
@@ -761,7 +761,7 @@ class ProbeMatcher:
                             }
                         ], self.soartech_sid, self.soartech_yaml['id'])                
                 if self.participantId == '202409112' and 'vol' in self.environment:
-                    self.send_probes(f'{ST_URL}/api/v1/response', 
+                    self.send_probes(f'{ST_URL}api/v1/response', 
                         [
                             { 
                                 "scene_id": 'id-6',
@@ -794,8 +794,8 @@ class ProbeMatcher:
                                                                       session2_probes=4.5&session2_probes=4.6&session2_probes=4.8&session2_probes=4.9&session2_probes=4.10&\
                                                                       session2_probes=vol-dre-train2-Probe-11&session2_probes=vol-dre-train2-Probe-12')
                     else:
-                        st_align[target] = self.get_session_alignment(f'{ST_URL}/api/v1/alignment/session?session_id={self.soartech_sid}&target_id={target}')
-                st_align['kdmas'] = self.get_session_alignment(f'{ST_URL}/api/v1/computed_kdma_profile?session_id={self.soartech_sid}')
+                        st_align[target] = self.get_session_alignment(f'{ST_URL}api/v1/alignment/session?session_id={self.soartech_sid}&target_id={target}')
+                st_align['kdmas'] = self.get_session_alignment(f'{ST_URL}api/v1/computed_kdma_profile?session_id={self.soartech_sid}')
                 st_align['sid'] = self.soartech_sid
             except:
                 self.logger.log(LogLevel.WARN, "Session Alignment Get Request failed")
@@ -1077,10 +1077,10 @@ class ProbeMatcher:
                 targets = ['ADEPT-DryRun-Moral judgement-0.0', 'ADEPT-DryRun-Ingroup Bias-0.0', 'ADEPT-DryRun-Moral judgement-0.1', 'ADEPT-DryRun-Ingroup Bias-0.1', 'ADEPT-DryRun-Moral judgement-0.2', 'ADEPT-DryRun-Ingroup Bias-0.2', 'ADEPT-DryRun-Moral judgement-0.3', 
                         'ADEPT-DryRun-Ingroup Bias-0.3', 'ADEPT-DryRun-Moral judgement-0.4', 'ADEPT-DryRun-Ingroup Bias-0.4', 'ADEPT-DryRun-Moral judgement-0.5', 'ADEPT-DryRun-Ingroup Bias-0.5', 'ADEPT-DryRun-Moral judgement-0.6', 'ADEPT-DryRun-Ingroup Bias-0.6', 'ADEPT-DryRun-Moral judgement-0.7', 'ADEPT-DryRun-Ingroup Bias-0.7', 'ADEPT-DryRun-Moral judgement-0.8', 
                         'ADEPT-DryRun-Ingroup Bias-0.8', 'ADEPT-DryRun-Moral judgement-0.9', 'ADEPT-DryRun-Ingroup Bias-0.9', 'ADEPT-DryRun-Moral judgement-1.0', 'ADEPT-DryRun-Ingroup Bias-1.0']
-                self.send_probes(f'{ADEPT_URL}/api/v1/response', match_data, self.adept_sid, self.adept_yaml['id'])
+                self.send_probes(f'{ADEPT_URL}api/v1/response', match_data, self.adept_sid, self.adept_yaml['id'])
                 for target in targets:
-                    ad_align[target] = self.get_session_alignment(f'{ADEPT_URL}/api/v1/alignment/session?session_id={self.adept_sid}&target_id={target}&population=false')
-                ad_align['kdmas'] = self.get_session_alignment(f'{ADEPT_URL}/api/v1/computed_kdma_profile?session_id={self.adept_sid}')
+                    ad_align[target] = self.get_session_alignment(f'{ADEPT_URL}api/v1/alignment/session?session_id={self.adept_sid}&target_id={target}&population=false')
+                ad_align['kdmas'] = self.get_session_alignment(f'{ADEPT_URL}api/v1/computed_kdma_profile?session_id={self.adept_sid}')
                 ad_align['sid'] = self.adept_sid
             except:
                 self.logger.log(LogLevel.WARN, "Session Alignment Get Request failed")
@@ -1343,8 +1343,8 @@ if __name__ == '__main__':
                     print(f"\n** Processing {f} **")
                     # json found! grab matching csv and send to the probe matcher
                     try:
-                        adept_sid = requests.post(f'{ADEPT_URL}/api/v1/new_session').text.replace('"', '').strip()
-                        soartech_sid = requests.post(f'{ST_URL}/api/v1/new_session?user_id=default_use').json()
+                        adept_sid = requests.post(f'{ADEPT_URL}api/v1/new_session').text.replace('"', '').strip()
+                        soartech_sid = requests.post(f'{ST_URL}api/v1/new_session?user_id=default_use').json()
                         matcher = ProbeMatcher(os.path.join(parent, f), adept_sid, soartech_sid)
                         # matcher = ProbeMatcher(os.path.join(parent, f), None, None) # use this for basic matching testing when SSL is not working
                         if matcher.environment != '' and matcher.analyze:

--- a/dre_repop_adept_sessions.py
+++ b/dre_repop_adept_sessions.py
@@ -126,26 +126,26 @@ def main():
     client = MongoClient(MONGO_URL)
     mongoDB = client['dashboard']
 
-    # print("Repopulating ADEPT Text/ADM Sessions")
-    # update_adept_text_adm_sessions(mongoDB)
+    print("Repopulating ADEPT Text/ADM Sessions")
+    update_adept_text_adm_sessions(mongoDB)
 
-    # print("Clean intermediate collections")
-    # delegationADMRuns_cur = mongoDB['delegationADMRuns']
-    # delegationADMRuns_cur.drop()
-    # humanToADMComparison_cur = mongoDB['humanToADMComparison']
-    # humanToADMComparison_cur.delete_many({"text_scenario" : {"$regex" : "DryRunEval"}})
+    print("Clean intermediate collections")
+    delegationADMRuns_cur = mongoDB['delegationADMRuns']
+    delegationADMRuns_cur.drop()
+    humanToADMComparison_cur = mongoDB['humanToADMComparison']
+    humanToADMComparison_cur.delete_many({"text_scenario" : {"$regex" : "DryRunEval"}})
 
-    # print("Rerunning `get_text_scenario_kdmas`")
-    # get_text_scenario_kdmas(mongoDB)
+    print("Rerunning `get_text_scenario_kdmas`")
+    get_text_scenario_kdmas(mongoDB)
 
-    # print("Rerunning `compare_probes`")
-    # compare_probes(mongoDB)
+    print("Rerunning `compare_probes`")
+    compare_probes(mongoDB)
 
-    # print("Rerunning `run_group_targets`")
-    # run_group_targets(mongoDB)
+    print("Rerunning `run_group_targets`")
+    run_group_targets(mongoDB)
 
-    # print("Rerunning `find_matching_probe_percentage`")
-    # find_matching_probe_percentage(mongoDB)
+    print("Rerunning `find_matching_probe_percentage`")
+    find_matching_probe_percentage(mongoDB)
 
     print("Rerunning `fix_participant_id`")
     fix_participant_id(mongoDB)        

--- a/dre_repop_adept_sessions.py
+++ b/dre_repop_adept_sessions.py
@@ -5,6 +5,8 @@ from scripts._0_2_6_add_text_kdmas import get_text_scenario_kdmas
 from scripts._0_2_8_human_to_adm_comparison import compare_probes
 from scripts._0_2_9_run_group_targets import run_group_targets
 from scripts._0_3_0_percent_matching_probes import find_matching_probe_percentage
+from scripts._0_3_2_update_participant_log import fix_participant_id
+
 
 VERSION_COLLECTION = "itm_version"
 MONGO_URL = config('MONGO_URL')
@@ -124,26 +126,29 @@ def main():
     client = MongoClient(MONGO_URL)
     mongoDB = client['dashboard']
 
-    print("Repopulating ADEPT Text/ADM Sessions")
-    update_adept_text_adm_sessions(mongoDB)
+    # print("Repopulating ADEPT Text/ADM Sessions")
+    # update_adept_text_adm_sessions(mongoDB)
 
-    print("Clean intermediate collections")
-    delegationADMRuns_cur = mongoDB['delegationADMRuns']
-    delegationADMRuns_cur.drop()
-    humanToADMComparison_cur = mongoDB['humanToADMComparison']
-    humanToADMComparison_cur.delete_many({"text_scenario" : {"$regex" : "DryRunEval"}})
+    # print("Clean intermediate collections")
+    # delegationADMRuns_cur = mongoDB['delegationADMRuns']
+    # delegationADMRuns_cur.drop()
+    # humanToADMComparison_cur = mongoDB['humanToADMComparison']
+    # humanToADMComparison_cur.delete_many({"text_scenario" : {"$regex" : "DryRunEval"}})
 
-    print("Rerunning `get_text_scenario_kdmas`")
-    get_text_scenario_kdmas(mongoDB)
+    # print("Rerunning `get_text_scenario_kdmas`")
+    # get_text_scenario_kdmas(mongoDB)
 
-    print("Rerunning `compare_probes`")
-    compare_probes(mongoDB)
+    # print("Rerunning `compare_probes`")
+    # compare_probes(mongoDB)
 
-    print("Rerunning `run_group_targets`")
-    run_group_targets(mongoDB)
+    # print("Rerunning `run_group_targets`")
+    # run_group_targets(mongoDB)
 
-    print("Rerunning `find_matching_probe_percentage`")
-    find_matching_probe_percentage(mongoDB)    
+    # print("Rerunning `find_matching_probe_percentage`")
+    # find_matching_probe_percentage(mongoDB)
+
+    print("Rerunning `fix_participant_id`")
+    fix_participant_id(mongoDB)        
 
 if __name__ == "__main__":
     main()

--- a/scripts/_0_0_8_add_textbased_alignment.py
+++ b/scripts/_0_0_8_add_textbased_alignment.py
@@ -128,7 +128,7 @@ def get_alignment_data(url_base, session_id, target_id):
     return response.json() if response.status_code == 200 else None
 
 def get_adept_alignment(scenario_results, scenario_id):
-    url = f"{ADEPT_URL}/api/v1/new_session"
+    url = f"{ADEPT_URL}api/v1/new_session"
     start_session = requests.post(url)
     if start_session.status_code == 200:
         session_id = start_session.json()
@@ -142,7 +142,7 @@ def get_adept_alignment(scenario_results, scenario_id):
         scenario_results['serverSessionId'] = session_id
 
 def get_soartech_alignment(scenario_results, scenario_id):
-    url = f"{ST_URL}/api/v1/new_session?user_id=default_user"
+    url = f"{ST_URL}api/v1/new_session?user_id=default_user"
     start_session = requests.post(url)
     if start_session.status_code == 201:
         session_id = start_session.json()

--- a/scripts/_0_2_6_add_text_kdmas.py
+++ b/scripts/_0_2_6_add_text_kdmas.py
@@ -1,7 +1,8 @@
 import requests
+from decouple import config 
 
-ADEPT_URL = "https://darpaitm.caci.com/adept/"
-ST_URL = "https://darpaitm.caci.com/soartech/" 
+ADEPT_URL = config("ADEPT_DRE_URL")
+ST_URL = config("ST_DRE_URL")
 
 def get_text_scenario_kdmas(mongoDB):
     text_scenario_collection = mongoDB['userScenarioResults']

--- a/scripts/_0_2_8_human_to_adm_comparison.py
+++ b/scripts/_0_2_8_human_to_adm_comparison.py
@@ -1,8 +1,9 @@
 import requests
 import utils.db_utils as db_utils
+from decouple import config 
 
-ADEPT_URL = "https://darpaitm.caci.com/adept/"
-ST_URL = "https://darpaitm.caci.com/soartech/" 
+ADEPT_URL = config("ADEPT_DRE_URL")
+ST_URL = config("ST_DRE_URL")
 
 ST_PROBES = {
     "qol-dre-1-eval": ['4.2', '4.3', '4.6', '4.7', '4.10', 'qol-dre-train2-Probe-11'],

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -1,13 +1,15 @@
 import requests
-ADEPT_URL = "https://darpaitm.caci.com/adept/"
-ST_URL = "https://darpaitm.caci.com/soartech/" 
+from decouple import config 
+
+ADEPT_URL = config("ADEPT_DRE_URL")
+ST_URL = config("ST_DRE_URL")
 
 
 def mini_adm_run(collection, probes, target, adm_name):
-    adept_sid = requests.post(f'{ADEPT_URL}/api/v1/new_session').text.replace('"', "").strip()
+    adept_sid = requests.post(f'{ADEPT_URL}api/v1/new_session').text.replace('"', "").strip()
     scenario = None
     for x in probes:
-        requests.post(f'{ADEPT_URL}/api/v1/response', json={
+        requests.post(f'{ADEPT_URL}api/v1/response', json={
             "response": {
                 "choice": x['choice'],
                 "justification": x["justification"],
@@ -17,7 +19,7 @@ def mini_adm_run(collection, probes, target, adm_name):
             "session_id": adept_sid
         })
         scenario = x['scenario_id']
-    alignment = requests.get(f'{ADEPT_URL}/api/v1/alignment/session?session_id={adept_sid}&target_id={target}&population=false').json()
+    alignment = requests.get(f'{ADEPT_URL}api/v1/alignment/session?session_id={adept_sid}&target_id={target}&population=false').json()
     doc = {'session_id': adept_sid, 'probes': probes, 'alignment': alignment, 'target': target, 'scenario': scenario, 'adm_name': adm_name, 'evalNumber': 4}
     collection.insert_one(doc)
     return doc


### PR DESCRIPTION
This is live and running on prod... Let me know if you see anything wrong on the Prod Dashboard (https://darpaitm.caci.com/)

1. Standardize all the URL's
  a. Note: for some reason the double slash (//) throws an error with SoarTech
2. There are now DRE and Current Eval end points for ADEPT/SoarTech
  a. SoarTech requires a wipe of the DB for the new scenarios and we need to persist SoarTech DRE data

SoarTech
[darpaitm.caci.com/soartech_dre/api/v1/alignment_targets](https://darpaitm.caci.com/soartech_dre/api/v1/alignment_targets)
[darpaitm.caci.com/soartech/api/v1/alignment_targets](https://darpaitm.caci.com/soartech/api/v1/alignment_targets)
Adept
[darpaitm.caci.com/adept/api/v1/alignment_target_ids](https://darpaitm.caci.com/adept/api/v1/alignment_target_ids)
[darpaitm.caci.com/adept_dre/api/v1/alignment_target_ids](https://darpaitm.caci.com/adept_dre/api/v1/alignment_target_ids)

4. TA1 URL's are managed from .env
5. Single script to update DRE ADEPT Sessions
  a. dre_repop_adept_sessions.py