### PR TITLE
script for updating plog

### DIFF
--- a/scripts/_0_3_5_participant_log_p1_update.py
+++ b/scripts/_0_3_5_participant_log_p1_update.py
@@ -1,0 +1,42 @@
+def participant_log_p1_update(mongo_db):
+    participant_log = mongo_db['participantLog']
+    result = participant_log.delete_many({
+        '$or': [
+            {'claimed': {'$ne': True}},
+            {'claimed': {'$exists': False}}
+        ]
+    })
+
+    example_civ = {
+        'Type': 'Civ',
+        'ParticipantID': 202411101,
+        'Text-1': 'AD-1',
+        'Text-2': 'ST-1',
+        'Sim-1': 'AD-2',
+        'Sim-2': 'ST-2',
+        'Del-1': 'AD-3',
+        'Del-2': 'ST-3',
+        'ADMOrder': 3,
+        'claimed': False,
+        'simEntryCount': 0,
+        'surveyEntryCount': 0,
+        'textEntryCount': 0 
+    }
+
+    example_mil = {
+        'Type': 'Mil',
+        'ParticipantID': 2024011101,
+        'Text-1': 'AD-1',
+        'Text-2': 'ST-1',
+        'Sim-1': 'AD-2',
+        'Sim-2': 'ST-2',
+        'Del-1': 'AD-3',
+        'Del-2': 'ST-3',
+        'ADMOrder': 1,
+        'claimed': False,
+        'simEntryCount': 0,
+        'surveyEntryCount': 0,
+        'textEntryCount': 0 
+    }
+    
+    participant_log.insert_many([example_civ, example_mil])

--- a/scripts/_0_3_5_participant_log_p1_update.py
+++ b/scripts/_0_3_5_participant_log_p1_update.py
@@ -9,22 +9,6 @@ def participant_log_p1_update(mongo_db):
 
     example_civ = {
         'Type': 'Civ',
-        'ParticipantID': 202411401,
-        'Text-1': 'AD-1',
-        'Text-2': 'ST-1',
-        'Sim-1': 'AD-2',
-        'Sim-2': 'ST-2',
-        'Del-1': 'AD-3',
-        'Del-2': 'ST-3',
-        'ADMOrder': 3,
-        'claimed': False,
-        'simEntryCount': 0,
-        'surveyEntryCount': 0,
-        'textEntryCount': 0 
-    }
-
-    example_mil = {
-        'Type': 'Mil',
         'ParticipantID': 202411301,
         'Text-1': 'AD-1',
         'Text-2': 'ST-1',
@@ -32,7 +16,7 @@ def participant_log_p1_update(mongo_db):
         'Sim-2': 'ST-2',
         'Del-1': 'AD-3',
         'Del-2': 'ST-3',
-        'ADMOrder': 1,
+        'ADMOrder': 3,
         'claimed': False,
         'simEntryCount': 0,
         'surveyEntryCount': 0,

--- a/scripts/_0_3_5_participant_log_p1_update.py
+++ b/scripts/_0_3_5_participant_log_p1_update.py
@@ -9,7 +9,7 @@ def participant_log_p1_update(mongo_db):
 
     example_civ = {
         'Type': 'Civ',
-        'ParticipantID': 202411101,
+        'ParticipantID': 202411401,
         'Text-1': 'AD-1',
         'Text-2': 'ST-1',
         'Sim-1': 'AD-2',
@@ -25,7 +25,7 @@ def participant_log_p1_update(mongo_db):
 
     example_mil = {
         'Type': 'Mil',
-        'ParticipantID': 2024011101,
+        'ParticipantID': 202411301,
         'Text-1': 'AD-1',
         'Text-2': 'ST-1',
         'Sim-1': 'AD-2',

--- a/scripts/_0_3_5_participant_log_p1_update.py
+++ b/scripts/_0_3_5_participant_log_p1_update.py
@@ -23,4 +23,4 @@ def participant_log_p1_update(mongo_db):
         'textEntryCount': 0 
     }
     
-    participant_log.insert_many([example_civ, example_mil])
+    participant_log.insert_many([example_civ])


### PR DESCRIPTION
`python3 deployment_script.py`

Clears out unclaimed participant ids from the participant log. Creates new participant id to be claimed. Use [this dashboard pr](https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/164) for testing. 

To test use the text scenario login:
<img width="625" alt="Screenshot 2024-11-19 at 8 39 02 AM" src="https://github.com/user-attachments/assets/577c1cf4-e9e5-4889-8e0a-068f265e1d79">

And then check the pid you were assigned on the pid lookup page after clicking through the scenarios:
<img width="1318" alt="Screenshot 2024-11-19 at 8 38 49 AM" src="https://github.com/user-attachments/assets/e2efe6cf-a921-43ea-89c9-547cc5df0e34">

The pid we entered earlier was marked as type `Civ`. So if you chose civ when completing the scenarios your pid should be `202411301`, if you chose mil it should be `202411302`. Even if you do military first, if you do a civ run the next time, the civ run should populate with pid `202411301` since that pid will be waiting to be claimed by a civ. 
