### PR TITLE
remove page titles

### DIFF
--- a/text_based_scenarios/convert_yaml_to_json_config.py
+++ b/text_based_scenarios/convert_yaml_to_json_config.py
@@ -159,6 +159,7 @@ def partition_doc(scenario, filename, eval_type):
 
         page = {
             'name': scene['id'],
+            'title': ' ',
             'scenario_id': scenario_id,
             'scenario_name': scenario['name'],
             'elements': []
@@ -209,7 +210,7 @@ def partition_doc(scenario, filename, eval_type):
 
         template_element = {
             'name': 'template ' + str(page['name']),
-            'title': page['name'],
+            'title': ' ',
             'type': 'medicalScenario',
             'unstructured': processed_unstructured,
             'supplies': current_supplies,


### PR DESCRIPTION
```
cd text_based_scenarios
python3 convert_yaml_to_json_config.py
```

Should remove page titles on pages. Can use review-text-scenario to test.

Before:
<img width="1728" alt="Screenshot 2024-11-22 at 10 34 00 AM" src="https://github.com/user-attachments/assets/26e27523-7665-4f66-8eb2-35c6b09bf840">


After:
<img width="1700" alt="Screenshot 2024-11-22 at 10 32 52 AM" src="https://github.com/user-attachments/assets/49c07f82-5354-4b6e-a4f0-f1eb003da605">

Note: I believe the grab for the configs is cached so you may have to do a hard refresh or close the tab and go back.