### PR TITLE
add hashed emails to participant log when hashedEmail=null

### DIFF
--- a/scripts/_0_3_7_add_hashed_emails.py
+++ b/scripts/_0_3_7_add_hashed_emails.py
@@ -1,0 +1,10 @@
+import hashlib
+
+def participant_log_p1_update(mongo_db):
+    participant_log = mongo_db['participantLog']
+    result = participant_log.find({'hashedEmail': None})
+
+    for doc in result:
+        pid = str(doc['ParticipantID']).encode('utf-8')
+        hashed_pid = hashlib.sha256(pid).hexdigest()
+        participant_log.update_one({'_id': doc['_id']}, {'$set': {'hashedEmail': hashed_pid}})


### PR DESCRIPTION
In order to set hashedEmail to a unique field in mongo, we need to not have any null values. This is a simple fix for that, setting the null hashedEmail values to the hashed value of the pid stored.