### PR TITLE
improved script 028 to have 'run-new-only' mode

### DIFF
--- a/ph1_weekly.py
+++ b/ph1_weekly.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
 
     # run script that compares humans to adms (RQ1/3/4 column Alignment score (Del|ADM))
     # RQ 5 Alignment score (Participant|ADM (most, least))
-    compare_probes(db, 5)
+    compare_probes(db, 5, True)
 
     # run matching script (RQ5 columns Match_MostAligned and Match_LeastAligned)
     find_matching_probe_percentage(db, 5)


### PR DESCRIPTION
Script _0_2_8 (which runs as part of the phase 1 weekly script) is VERY slow. Nobody likes it. This adds a new mode "run-new-only" that will only run the comparisons that do not already appear in the database. The weekly script runs this fast version. 

If your database is up to date, when you run this (by running the weekly script), you should see the errors from the surveys that are missing, and a few others that are expected, but it should run quickly. If you remove the "True" parameter, it should revert to its old, slow behavior. 