### PR TITLE
base probe matcher runs on database, not just output directory

### DIFF
--- a/ph1_probe_matcher.py
+++ b/ph1_probe_matcher.py
@@ -260,7 +260,6 @@ class ProbeMatcher:
             if not RUN_ALIGNMENT:
                 run_this_file = False
             if RUN_ALIGNMENT:
-                # TODO: update this based on database instead of output directory
                 if not SEND_TO_MONGO:
                     f = open(filename, 'r', encoding='utf-8')
                     data = json.load(f)


### PR DESCRIPTION
Perhaps this has only been a problem for me, but I will sometimes run the probe matcher locally, then download the most recent database which has not had probe matcher run. It will undo all of my database probe matcher changes, but since I have the files locally, probe matcher does not rerun those files and repopulate the database.

This makes sure probe matcher runs based on the database as well as the output directory, not just the local directory. To test, remove an entry from your local database and rerun probe matcher with the weekly setting. You should see it stop _once_ to recalculate the probes and alignment for that one entry. 

As a more important, related change:
The KDMAs added from Darren's 0_4_2 script were being overwritten because of the run_comparison function. This ensures that when the weekly script is run, the alignment data for comparison is grabbed from the database rather than from local files (the local files don't have kdmas). To test, run Darren's script and the old probe matcher (with the weekly setting on). For a faster run, only run the sim part of Darren's script. Notice in the dashboard (check http://localhost:3000/humanSimParticipant) that all the sim kdmas disappear. Now do it again, this time running this updated probe matcher. All the data should remain. 