### PR TITLE
Calculate dre comparisons using ph1 server

### DIFF
--- a/delegation_survey/rerun_all_delegation.py
+++ b/delegation_survey/rerun_all_delegation.py
@@ -1,0 +1,22 @@
+'''
+We need the names of the adms to match what they were when the surveys were taken.
+
+At some point, it appears the entire admMedics collection was deleted. So we need to run
+convert_adms_for_delegation, then ph1_dre_adms_for_delegation with eval4.
+
+Then we need to run ph1_dre_adms_for_delegation with eval5 without basing names on previous evals
+'''
+
+import os
+from decouple import config 
+
+if __name__ == "__main__":
+    from pymongo import MongoClient
+    MONGO_URL = config('MONGO_URL')
+    client = MongoClient(MONGO_URL)
+    db = client.dashboard
+    medic_mongo_collection = db['admMedics']
+    db['admMedics'].delete_many({})
+    os.system('python3 convert_adms_for_delegation.py')
+    os.system('python3 ph1_dre_adms_for_delegation.py -e 4')
+    os.system('python3 ph1_dre_adms_for_delegation.py -e 5')

--- a/scripts/_0_4_5_adept_human_adm_compare_DRE_PH1_Server.py
+++ b/scripts/_0_4_5_adept_human_adm_compare_DRE_PH1_Server.py
@@ -1,0 +1,168 @@
+import requests
+import utils.db_utils as db_utils
+from decouple import config 
+
+# compares the text responses for adept from DRE using the Phase 1 server
+# first, we have to recreate all of the adept sessions for ADEPT DRE text on the Phase 1 server
+# then, we have to create the "mini-adms" on the phase 1 server
+# finally, we can compare
+
+ADEPT_URL = config("ADEPT_URL")
+
+AD_PROBES = {
+    "DryRunEval-IO2-eval": ['Probe 4', 'Probe 8', 'Probe 9', 'Probe 9-B.1', 'Probe 9-A.1', 'Probe 10'],
+    "DryRunEval-MJ2-eval": ['Probe 2B-1', 'Probe 2A-1', 'Response 3-B.2-B-gauze-v', 'Response 3-B.2-B-gauze-s', 'Response 3-B.2-A-gauze-v', 'Response 3-B.2-A-gauze-s', 'Probe 5', 'Probe 5-A.1', 'Probe 5-B.1', 'Probe 6', 'Probe 7'],
+    "DryRunEval-IO4-eval": ['Probe 6', 'Probe 7', 'Probe 8', 'Probe 10'],
+    "DryRunEval-MJ4-eval": ['Probe 1', 'Probe 2 kicker', 'Probe 2 passerby', 'Probe 2-A.1', 'Probe 2-D.1', 'Probe 2-D.1-B.1', 'Probe 3', 'Probe 3-A.1', 'Probe 3-B.1', 'Probe 9', 'Response 10-B', 'Response 10-C', 'Probe 10-A.1'],
+    "DryRunEval-IO5-eval": ['Probe 7', 'Probe 8', 'Probe 8-A.1', 'Probe 8-A.1-A.1', 'Probe 9', 'Probe 9-A.1', 'Probe 9-B.1', 'Probe 9-C.1'],
+    "DryRunEval-MJ5-eval": ['Probe 1', 'Probe 1-A.1', 'Probe 1-B.1', 'Probe 2', 'Response 2-A.1-B', 'Response 2-B.1-B', 'Response 2-B.1-B-gauze-u', 'Response 2-A.1-B-gauze-sp', 'Probe 2-A.1-A.1', 'Probe 2-B.1-A.1', 'Probe 2-A.1-B.1-A.1', 'Probe 2-B.1-B.1-A.1', 'Probe 3', 'Probe 4']
+}
+
+def main(mongoDB, EVAL_NUMBER=4):
+    text_scenario_collection = mongoDB['userScenarioResults']
+    delegation_collection = mongoDB['surveyResults']
+    comparison_collection = mongoDB['humanToADMComparison']
+    medic_collection = mongoDB['admMedics']
+    adm_collection = mongoDB["test"]
+    del_adm_runs_collection = mongoDB['delegationADMRuns']
+
+    data_to_use = text_scenario_collection.find(
+        {"evalNumber": EVAL_NUMBER}
+    )
+
+    # start by creating sessions in phase 1 server for dre data
+    sessions_by_pid = {}
+    for entry in data_to_use:
+        scenario_id = entry.get('scenario_id')
+        ph1_id = entry.get('ph1SessionId', None)
+        session_id = entry.get('combinedSessionId', entry.get('serverSessionId'))
+        data_id = entry.get('_id')
+        pid = entry.get('participantID')
+        
+        new_id = None
+        if 'DryRun' in scenario_id and ph1_id is None:
+            if pid in sessions_by_pid:
+                new_id = sessions_by_pid[pid]['sid']
+                sessions_by_pid[pid]['_ids'].append(data_id)
+            else:
+                adept_sid = requests.post(f'{ADEPT_URL}api/v1/new_session').text.replace('"', '').strip()
+                sessions_by_pid[pid] = {'sid': adept_sid, '_ids': [data_id]}
+                new_id = adept_sid
+            # collect probes
+            probes = []
+            for k in entry:
+                if isinstance(entry[k], dict) and 'questions' in entry[k]:
+                    if 'probe ' + k in entry[k]['questions'] and 'response' in entry[k]['questions']['probe ' + k] and 'question_mapping' in entry[k]['questions']['probe ' + k]:
+                        response = entry[k]['questions']['probe ' + k]['response'].replace('.', '')
+                        mapping = entry[k]['questions']['probe ' + k]['question_mapping']
+                        if response in mapping:
+                            probes.append({'probe': {'choice': mapping[response]['choice'], 'probe_id': mapping[response]['probe_id']}})
+                        else:
+                            print('could not find response in mapping!', response, list(mapping.keys()))
+            send_probes(f'{ADEPT_URL}api/v1/response', probes, new_id, scenario_id)
+
+        updates = {}
+        if new_id is not None:
+            # only applies to ADEPT, ST did not lose data
+            updates['ph1SessionId'] = new_id
+            # if new_id exists, we need to update the session id for all adept that this participant completed (we never know when it will be the last one)
+            for data_id in sessions_by_pid[pid]['_ids']:
+                text_scenario_collection.update_one({'_id': data_id}, {'$set': updates})        
+
+
+    # go through text scenarios again, this time finding comparison values
+    text_scenario_collection = mongoDB['userScenarioResults']
+    data_to_use = text_scenario_collection.find(
+        {"evalNumber": EVAL_NUMBER}
+    )
+    for entry in data_to_use:
+        scenario_id = entry.get('scenario_id')
+        if 'MJ1' in scenario_id or 'IO1' in scenario_id:
+            # ignore test scenarios from adept
+            continue
+        session_id = entry.get('ph1SessionId', None)
+        pid = entry.get('participantID')
+        survey = list(delegation_collection.find({"results.Participant ID Page.questions.Participant ID.response": pid}))
+        if len(survey) == 0:
+            print(f"No survey found for {pid}")
+            continue
+        survey = survey[-1] # get last survey entry for this pid
+        # get human to adm comparisons from delegation survey adms
+        for page in survey['results']:
+            if 'Medic' in page and ' vs ' not in page:
+                page_scenario = survey['results'][page]['scenarioIndex']
+                # ignore ST 
+                if ('qol' in scenario_id and 'qol' in page_scenario) or ('vol' in scenario_id and 'vol' in page_scenario):
+                    continue
+                elif (('DryRunEval' in scenario_id or 'adept' in scenario_id) and ('DryRunEval' in page_scenario or 'adept' in page_scenario)):
+                    adm = db_utils.find_adm_from_medic(EVAL_NUMBER, medic_collection, adm_collection, page, page_scenario.replace('IO', 'MJ'), survey)
+                    if adm is None:
+                        continue
+                    adm_target = adm['history'][len(adm['history'])-1]['parameters']['target_id']
+                    found_mini_adm = del_adm_runs_collection.find_one({'dre_ph1_run': True, 'target': adm_target, 'evalNumber': EVAL_NUMBER, 'scenario': page_scenario.replace('IO', 'MJ'), 'adm_name': survey['results'][page]['admName']})
+                    if found_mini_adm is None:
+                        # get new adm session
+                        probe_ids = AD_PROBES[page_scenario] # this is where IO/MJ comes into play - choosing the probes
+                        probe_responses = []
+                        for x in adm['history']:
+                            if x['command'] == 'Respond to TA1 Probe':
+                                if x['parameters']['choice'] in probe_ids or x['parameters']['probe_id'] in probe_ids:
+                                    probe_responses.append(x['parameters'])
+                        found_mini_adm = db_utils.mini_adm_run(EVAL_NUMBER, del_adm_runs_collection, probe_responses, adm_target, survey['results'][page]['admName'], True)
+                    
+                    # get comparison score
+                    res = requests.get(f'{ADEPT_URL}api/v1/alignment/compare_sessions?session_id_1={session_id}&session_id_2={found_mini_adm["session_id"]}').json()
+                    # send document to mongo
+                    if res is not None and 'score' in res:
+                        document = {
+                            'pid': pid,
+                            'adm_type': survey['results'][page]['admAlignment'],
+                            'score': res['score'],
+                            'text_scenario': scenario_id,
+                            'text_session_id': session_id.replace('"', "").strip(),
+                            'adm_scenario': page_scenario,
+                            'adm_session_id': found_mini_adm["session_id"],
+                            'adm_author': survey['results'][page]['admAuthor'],
+                            'adm_alignment_target': survey['results'][page]['admTarget'],
+                            'evalNumber': EVAL_NUMBER,
+                            'ph1_server': True
+                        }
+                        send_document_to_mongo(comparison_collection, document)
+                    else:
+                        print(f'Error getting comparison for scenarios {scenario_id} and {page_scenario} with text session {session_id} and adm session {found_mini_adm["session_id"]}', res)
+
+
+    print("Human to ADM comparison values added to database.")
+
+
+def send_probes(probe_url, probes, sid, scenario):
+    '''
+    Sends the probes to the server
+    '''
+    for x in probes:
+        if 'probe' in x and 'choice' in x['probe']:
+            requests.post(probe_url, json={
+                "response": {
+                    "choice": x['probe']['choice'],
+                    "justification": "justification",
+                    "probe_id": x['probe']['probe_id'],
+                    "scenario_id": scenario,
+                },
+                "session_id": sid
+            })
+        
+
+def send_document_to_mongo(comparison_collection, document):
+    # do not send duplicate documents, make sure if one already exists, we just replace it
+    found_docs = comparison_collection.find({'ph1_server': document['ph1_server'], 'pid': document['pid'], 'adm_type': document['adm_type'], 'text_scenario': document['text_scenario'], 'adm_scenario': document['adm_scenario'], 'evalNumber': document['evalNumber'],
+                                            'text_session_id': document['text_session_id'], 'adm_session_id': document['adm_session_id'], 'adm_author': document['adm_author'], 'adm_alignment_target': document['adm_alignment_target']})
+    doc_found = False
+    obj_id = ''
+    for doc in found_docs:
+        doc_found = True
+        obj_id = doc['_id']
+        break
+    if doc_found:
+        comparison_collection.update_one({'_id': obj_id}, {'$set': document})
+    else:
+        comparison_collection.insert_one(document)

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -16,8 +16,8 @@ PH1_SCENARIO_MAP = {
     "vol-ph1-eval-4": "vol-ph1-eval-4"
 }
 
-def mini_adm_run(evalNumber, collection, probes, target, adm_name):
-    ADEPT_URL = config("ADEPT_DRE_URL") if evalNumber == 4 else config('ADEPT_URL')
+def mini_adm_run(evalNumber, collection, probes, target, adm_name, dre_ph1_run=False):
+    ADEPT_URL = config("ADEPT_DRE_URL") if evalNumber == 4 and not dre_ph1_run else config('ADEPT_URL')
     adept_sid = requests.post(f'{ADEPT_URL}api/v1/new_session').text.replace('"', "").strip()
     scenario = None
     for x in probes:
@@ -31,7 +31,7 @@ def mini_adm_run(evalNumber, collection, probes, target, adm_name):
             "session_id": adept_sid
         })
         scenario = x['scenario_id']
-    if evalNumber == 4:
+    if evalNumber == 4 and not dre_ph1_run:
         alignment = requests.get(f'{ADEPT_URL}api/v1/alignment/session?session_id={adept_sid}&target_id={target}&population=false').json()
     else:
         if 'Moral' in target:
@@ -45,6 +45,8 @@ def mini_adm_run(evalNumber, collection, probes, target, adm_name):
                 break
         alignment = {'alignment_source': {'score': score}}
     doc = {'session_id': adept_sid, 'probes': probes, 'alignment': alignment, 'target': target, 'scenario': scenario, 'adm_name': adm_name, 'evalNumber': evalNumber}
+    if dre_ph1_run:
+        doc['dre_ph1_run'] = True
     collection.insert_one(doc)
     return doc
 
@@ -60,7 +62,7 @@ def find_adm_from_medic(eval_number, medic_collection, adm_collection, page, pag
             adm = x
             break
     if adm is None:
-        print(f"No matching adm found for scenario {page_scenario} with adm {survey['results'][page]['admName']} (session {adm_session})")
+        print(f"No matching adm found for scenario {page_scenario} with adm {survey['results'][page]['admName']} (session {adm_session}) (target {survey['results'][page]['admTarget']})")
         return None
     return adm
 


### PR DESCRIPTION
Jennifer wanted to see the text/adm comparisons (based on the delegation survey only (i.e. not most/least aligned)) for the DRE participants using the Phase 1 server, since ADEPT changed their comparison calculation. 

This required several steps:
1. Re-send text probes from all 3 ADEPT text scenarios (MJ1, IO1, and the eval scenario) to the phase 1 server to create a new session
2. Create the "mini-adms" (aka delegation adms, which use only a subset of probes depending on IO vs MJ) on the phase 1 server
3. Generate the comparison for those two newly-create session and store it 

The text scenario now has an optional parameter ph1SessionId which corresponds to the session id on the phase 1 server without compromising the dre session id. The comparison collection has an optional parameter ph1_server which shows whether the score was gotten from ph1 or dre. 

While working on this task, I discovered that at some point, the entire admMedic collection was wiped clean, so all of our eval4 medics are gone. Because of the way naming works, I had to create a new script to repopulate the admMedic collection in the correct order. First, it runs eval 3, then eval 4, then eval 5, but for eval 5 the naming starts from scratch. 

To run:
`cd delegation_survey`
`python3 rerun_all_delegation.py`
`cd ..`
`python3 deployment_script.py`

Note that this script is 0_4_5. 0_4_4 is the group targets, which will likely be merged before this one. If you test out of order,  you'll have to play around with the script numbers. If this gets merged first, I will change it to 044.

View https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/221 afterwards