### PR TITLE
Itm 819

### DIFF
--- a/scripts/_0_4_8_replace_st_group_and_rename.py
+++ b/scripts/_0_4_8_replace_st_group_and_rename.py
@@ -34,15 +34,20 @@ def main(mongo_db):
                     delete_count += 1
 
             if history[start_index]['parameters']['adm_name'] == 'ALIGN-ADM-ComparativeRegression-Llama-3.2-3B-Instruct-SoarTech-MatchingChars__67b51a1b-f06e-4667-a2ce-a52c84a85a70':
-                #replace name
-                adm_collection.update_one(
-                    {"_id": adm["_id"]},
-                    {
-                        "$set": {
-                            f"history.{align_index}.parameters.adm_name": "ALIGN-ADM-ComparativeRegression-ICL-Template"
+                # sometime start scenario is index 0 and sometimes index 1.. accounted for
+                updates = {}
+                for i in range(0, start_index + 1):
+                    if ('parameters' in history[i] and 
+                        'adm_name' in history[i]['parameters']):
+                        updates[f"history.{i}.parameters.adm_name"] = "ALIGN-ADM-ComparativeRegression-ICL-Template"
+                
+                if updates:
+                    adm_collection.update_one(
+                        {"_id": adm["_id"]},
+                        {
+                            "$set": updates
                         }
-                    }
-                )
-                rename_count += 1
+                    )
+                    rename_count += 1
     
     print(f'Processed documents: {delete_count} deleted, {rename_count} renamed')

--- a/scripts/_0_4_8_replace_st_group_and_rename.py
+++ b/scripts/_0_4_8_replace_st_group_and_rename.py
@@ -1,0 +1,48 @@
+to_remove = [
+    "qol-group-target-1-final-eval",
+    "qol-group-target-2-final-eval",
+    "vol-group-target-1-final-eval",
+    "vol-group-target-2-final-eval"
+]
+
+def main(mongo_db):
+    adm_collection = mongo_db['test']
+    eval_5_adms = adm_collection.find({"evalNumber": 5})
+    
+    delete_count = 0
+    rename_count = 0
+    
+    for adm in eval_5_adms:
+        history = adm['history']
+        start_index = -1
+        align_index = -1
+        
+        for i, el in enumerate(history):
+            if el['command'] == 'Start Scenario':
+                start_index = i
+            if el['command'] == 'Alignment Target':
+                align_index = i
+                break
+
+        if align_index >= 0 and start_index >= 0:
+            start = history[start_index]
+            align = history[align_index]
+            if start['parameters']['adm_name'] == 'ALIGN-ADM-ComparativeRegression-ICL-Template':
+                # remove old group run
+                if align['response']['id'] in to_remove:
+                    adm_collection.delete_one({"_id": adm["_id"]})
+                    delete_count += 1
+
+            if history[start_index]['parameters']['adm_name'] == 'ALIGN-ADM-ComparativeRegression-Llama-3.2-3B-Instruct-SoarTech-MatchingChars__67b51a1b-f06e-4667-a2ce-a52c84a85a70':
+                #replace name
+                adm_collection.update_one(
+                    {"_id": adm["_id"]},
+                    {
+                        "$set": {
+                            f"history.{align_index}.parameters.adm_name": "ALIGN-ADM-ComparativeRegression-ICL-Template"
+                        }
+                    }
+                )
+                rename_count += 1
+    
+    print(f'Processed documents: {delete_count} deleted, {rename_count} renamed')


### PR DESCRIPTION
[Ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?assignee=60ba425da547eb00686ee0ce)

I got a backup from earlier today off AWS so message me if you need a fresh copy. 

http://localhost:3000/results

Click on any soartech scenario and notice the adm name `ALIGN-ADM-ComparativeRegression-Llama-3.2-3B-Instruct-SoarTech-MatchingChars__67b51a1b-f06e-4667-a2ce-a52c84a85a70`.

This script will rename all of those adms and replace the existing group target runs for `ALIGN-ADM-ComparativeRegression-ICL-Template`

After running the script you should have 12 removed adms (can check `test` collection count in mongo) and 12 renamed runs. Go back to the dashboard to do a spot check.  