### PR TITLE
Fix pids for participant that went through 

### DIFF
--- a/scripts/_0_5_0_fix_pid_jan_25.py
+++ b/scripts/_0_5_0_fix_pid_jan_25.py
@@ -1,0 +1,14 @@
+def main(mongo_db):
+    p_log = mongo_db['participantLog']
+    #update plog w new id
+    p_log.update_one(
+        {"ParticipantID": 202411371},
+        {"$set": {"ParticipantID": 202501700}}
+    )
+
+    #update the text scenario results they already took
+    text_scenarios = mongo_db['userScenarioResults']
+    text_scenarios.update_many(
+        {"participantID": "202411371"},  
+        {"$set": {"participantID": "202501700"}}
+    )

--- a/scripts/_0_5_0_fix_pid_jan_25.py
+++ b/scripts/_0_5_0_fix_pid_jan_25.py
@@ -9,6 +9,10 @@ def main(mongo_db):
     #update the text scenario results they already took
     text_scenarios = mongo_db['userScenarioResults']
     text_scenarios.update_many(
-        {"participantID": "202411371"},  
-        {"$set": {"participantID": "202501700"}}
-    )
+       {"participantID": "202411371"},
+       {"$set": {
+           "participantID": "202501700",
+           "evalNumber": 6,
+           "evalName": "Jan 2025 Eval"
+       }}
+   )


### PR DESCRIPTION
I had to grab the most up to date db to see this participant (pid `202411371`).

`python3 deployment_script.py`

Should see he/she updated to 20501700 in the plog in addition to their text-based results