### PR TITLE
More info easily available in test collection 

### DIFF
--- a/scripts/_0_5_1_test_collection_improvements.py
+++ b/scripts/_0_5_1_test_collection_improvements.py
@@ -1,0 +1,31 @@
+def main(mongo_db):
+    test_collection = mongo_db['test']
+    tests = test_collection.find({})
+    updated_count = 0
+    for test in tests:
+        # anything before mre is irrelevant, mre is probably irrelevant as well but follows same structure so why not
+        if test['evalNumber'] < 3:
+            continue
+        adm_name = None
+        scenario = None
+        alignment_target = None
+        history = test['history']
+        for el in history:
+            if el['command'] == 'Start Scenario':
+                adm_name = el['parameters']['adm_name']
+                scenario = el['response']['id']
+            if el['command'] == 'Alignment Target':
+                alignment_target = el['response']['id']
+            
+            if all([adm_name, scenario, alignment_target]):
+                test_collection.update_one(
+                    {'_id': test['_id']},
+                    {'$set': {
+                        'adm_name': adm_name,
+                        'scenario': scenario,
+                        'alignment_target': alignment_target
+                    }}
+                )
+                updated_count += 1
+                break
+    print(f"Updated {updated_count} documents")


### PR DESCRIPTION
This is a quality-of-life improvement for the `test` collection that contains our adm runs. Before, we had to click through the history array to see the adm name, scenario, and target. Now all of that info should be available at the root level, making it easier to query and sift through. 

`python3 deployment_script.py`

<img width="529" alt="Screenshot 2025-02-06 at 9 52 06 AM" src="https://github.com/user-attachments/assets/1fb1748a-70c2-400b-ab5a-67deb03af49a" />
