### PR TITLE
run all adms against all humans

### DIFF
--- a/scripts/_0_5_3_jan_eval_to_dre_server.py
+++ b/scripts/_0_5_3_jan_eval_to_dre_server.py
@@ -3,7 +3,6 @@ import requests
 from adept_repop_ph1 import SCENARIO_MAP
 import utils.db_utils as db_utils
 
-PH1_URL = config("ADEPT_URL")
 DRE_URL = config("ADEPT_DRE_URL")
 
 def main(db):

--- a/scripts/_0_5_3_jan_eval_to_dre_server.py
+++ b/scripts/_0_5_3_jan_eval_to_dre_server.py
@@ -1,0 +1,76 @@
+from decouple import config 
+import requests
+from adept_repop_ph1 import SCENARIO_MAP
+import utils.db_utils as db_utils
+
+PH1_URL = config("ADEPT_URL")
+DRE_URL = config("ADEPT_DRE_URL")
+
+def main(db):
+    # send all JAN sessions to DRE server
+    print("Populating DRE server with JAN Eval data")
+    send_JAN_to_DRE(db)
+
+def send_JAN_to_DRE(mongoDB, EVAL_NUMBER=6):
+    '''
+    Populates the DRE server with PH1 data
+    '''
+    text_scenario_collection = mongoDB['userScenarioResults']
+
+    data_to_use = text_scenario_collection.find(
+        {"evalNumber": EVAL_NUMBER}
+    )
+
+    # start by creating sessions in dre server for phase 1 data
+    sessions_by_pid = {}
+    for entry in data_to_use:
+        scenario_id = entry.get('scenario_id')
+        dre_id = entry.get('dreSessionId', None)
+        data_id = entry.get('_id')
+        pid = entry.get('participantID')
+        
+        new_id = None
+        if 'adept' in scenario_id and dre_id is None:
+            scenario_id = SCENARIO_MAP[scenario_id]
+            if pid in sessions_by_pid:
+                new_id = sessions_by_pid[pid]['sid']
+                sessions_by_pid[pid]['_ids'].append(data_id)
+            else:
+                adept_sid = requests.post(f'{DRE_URL}api/v1/new_session').text.replace('"', '').strip()
+                sessions_by_pid[pid] = {'sid': adept_sid, '_ids': [data_id]}
+                new_id = adept_sid
+            # collect probes
+            probes = []
+            for k in entry:
+                if isinstance(entry[k], dict) and 'questions' in entry[k]:
+                    for valid_key in [f'probe {k}', f'probe {k}_conditional']:
+                        probe_data = entry[k]['questions'].get(valid_key, {})
+                        if 'response' in probe_data and 'question_mapping' in probe_data:
+                            response = probe_data['response'].replace('.', '')
+                            mapping = probe_data['question_mapping']
+                            if response in mapping:
+                                if isinstance(mapping[response]['choice'], list):
+                                    for c in mapping[response]['choice']:
+                                        probes.append({'probe': {'choice': c, 'probe_id': mapping[response]['probe_id']}})
+                                else:
+                                    probes.append({'probe': {'choice': mapping[response]['choice'], 'probe_id': mapping[response]['probe_id']}})
+                            else:
+                                print('could not find response in mapping!', response, list(mapping.keys()))
+            db_utils.send_probes(f'{DRE_URL}api/v1/response', probes, new_id, scenario_id)
+
+        updates = {}
+        if new_id is not None:
+            updates['dreSessionId'] = new_id
+            # if new_id exists, we need to update the session id for all adept that this participant completed (we never know when it will be the last one)
+            for data_id in sessions_by_pid[pid]['_ids']:
+                text_scenario_collection.update_one({'_id': data_id}, {'$set': updates})        
+
+    print("JAN eval sent to ADEPT DRE server - ids updated.")
+        
+
+if __name__ == '__main__':
+    from pymongo import MongoClient
+    MONGO_URL = config('MONGO_URL')
+    client = MongoClient(MONGO_URL)
+    mongoDB = client['dashboard']
+    main(mongoDB)

--- a/scripts/_0_5_4_all_adms_vs_humans.py
+++ b/scripts/_0_5_4_all_adms_vs_humans.py
@@ -1,0 +1,176 @@
+import requests, sys, warnings
+from decouple import config 
+warnings.filterwarnings('ignore')
+
+# full set of probes for each ST scenario
+ST_PROBES = {
+    "qol-dre-1-eval": ['4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '4.10', 'qol-dre-train2-Probe-11', '12'],
+    "qol-dre-2-eval": ['qol-dre-2-eval-Probe-1', 'qol-dre-2-eval-Probe-2', 'qol-dre-2-eval-Probe-3', 'qol-dre-2-eval-Probe-4', 'qol-dre-2-eval-Probe-5', 'qol-dre-2-eval-Probe-6', 'qol-dre-2-eval-Probe-7', 'qol-dre-2-eval-Probe-8', 'qol-dre-2-eval-Probe-9', 'qol-dre-2-eval-Probe-10', 'qol-dre-2-eval-Probe-11', 'qol-dre-2-eval-Probe-12'],
+    "qol-dre-3-eval": ['qol-dre-3-eval-Probe-1', 'qol-dre-3-eval-Probe-2', 'qol-dre-3-eval-Probe-3', 'qol-dre-3-eval-Probe-4', 'qol-dre-3-eval-Probe-5', 'qol-dre-3-eval-Probe-6', 'qol-dre-3-eval-Probe-7', 'qol-dre-3-eval-Probe-8', 'qol-dre-3-eval-Probe-9', 'qol-dre-3-eval-Probe-10', 'qol-dre-3-eval-Probe-11', 'qol-dre-3-eval-Probe-12'],
+    "vol-dre-1-eval": ['4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '4.10', 'vol-dre-train2-Probe-11', 'vol-dre-train2-Probe-12'],
+    "vol-dre-2-eval": ['vol-dre-2-eval-Probe-1', 'vol-dre-2-eval-Probe-2', 'vol-dre-2-eval-Probe-3', 'vol-dre-2-eval-Probe-4', 'vol-dre-2-eval-Probe-5', 'vol-dre-2-eval-Probe-6', 'vol-dre-2-eval-Probe-7', 'vol-dre-2-eval-Probe-8', 'vol-dre-2-eval-Probe-9', 'vol-dre-2-eval-Probe-10', 'vol-dre-2-eval-Probe-11', 'vol-dre-2-eval-Probe-12'],
+    "vol-dre-3-eval": ['vol-dre-3-eval-Probe-1', 'vol-dre-3-eval-Probe-2', 'vol-dre-3-eval-Probe-3', 'vol-dre-3-eval-Probe-4', 'vol-dre-3-eval-Probe-5', 'vol-dre-3-eval-Probe-6', 'vol-dre-3-eval-Probe-7', 'vol-dre-3-eval-Probe-8', 'vol-dre-3-eval-Probe-9', 'vol-dre-3-eval-Probe-10', 'vol-dre-3-eval-Probe-11', 'vol-dre-3-eval-Probe-12'],
+    "qol-ph1-eval-2": ['qol-ph1-eval-2-Probe-1', 'qol-ph1-eval-2-Probe-2', 'qol-ph1-eval-2-Probe-3', 'qol-ph1-eval-2-Probe-4', 'qol-ph1-eval-2-Probe-5', 'qol-ph1-eval-2-Probe-6'],
+    "qol-ph1-eval-3": ['qol-ph1-eval-3-Probe-1', 'qol-ph1-eval-3-Probe-2', 'qol-ph1-eval-3-Probe-3', 'qol-ph1-eval-3-Probe-4', 'qol-ph1-eval-3-Probe-5', 'qol-ph1-eval-3-Probe-6'],
+    "qol-ph1-eval-4": ['qol-ph1-eval-4-Probe-1', 'qol-ph1-eval-4-Probe-2', 'qol-ph1-eval-4-Probe-3', 'qol-ph1-eval-4-Probe-4', 'qol-ph1-eval-4-Probe-5', 'qol-ph1-eval-4-Probe-6'],
+    "vol-ph1-eval-2": ['vol-ph1-eval-2-Probe-1', 'vol-ph1-eval-2-Probe-2', 'vol-ph1-eval-2-Probe-3', 'vol-ph1-eval-2-Probe-4', 'vol-ph1-eval-2-Probe-5', 'vol-ph1-eval-2-Probe-6'],
+    "vol-ph1-eval-3": ['vol-ph1-eval-3-Probe-1', 'vol-ph1-eval-3-Probe-2', 'vol-ph1-eval-3-Probe-3', 'vol-ph1-eval-3-Probe-4', 'vol-ph1-eval-3-Probe-5', 'vol-ph1-eval-3-Probe-6'],
+    "vol-ph1-eval-4": ['vol-ph1-eval-4-Probe-1', 'vol-ph1-eval-4-Probe-2', 'vol-ph1-eval-4-Probe-3', 'vol-ph1-eval-4-Probe-4', 'vol-ph1-eval-4-Probe-5', 'vol-ph1-eval-4-Probe-6']
+}
+
+scenario_map = {
+    "phase1-adept-eval-MJ2": "DryRunEval-MJ2-eval",
+    "phase1-adept-eval-MJ4": "DryRunEval-MJ4-eval",
+    "phase1-adept-eval-MJ5": "DryRunEval-MJ5-eval",
+    "phase1-adept-train-MJ1": "DryRunEval.MJ1",
+    "phase1-adept-train-IO1": "DryRunEval.IO1"
+}
+
+def main(mongo_db):
+    find_all_comparisons(mongo_db, 4)
+    find_all_comparisons(mongo_db, 5)
+    find_all_comparisons(mongo_db, 6)
+
+
+def find_all_comparisons(mongo_db, eval_num):
+    print(f'\n\033[36mStarting comparison-finding for eval {eval_num}\033[0m', flush=True)
+    ADEPT_URL = config('ADEPT_DRE_URL') # we only use DRE comparisons for ADEPT
+    ST_URL = config("ST_URL") if eval_num != 4 else config('ST_DRE_URL')
+    adms = mongo_db['test']
+    text_scenarios = mongo_db['userScenarioResults']
+    comparisons = mongo_db['humanToADMComparison']
+    matches_collection = mongo_db['admVsTextProbeMatches']
+
+    relevant_text = text_scenarios.find({'evalNumber': eval_num}, no_cursor_timeout=True)
+    text_count = text_scenarios.count_documents({'evalNumber': eval_num})
+
+    # for each text scenario, store the comparison between that scenario and all adms at all targets
+    for idx, entry in enumerate(relevant_text):
+        pid = entry['participantID']
+        scenario = entry['scenario_id']
+        # skip adept training scenarios
+        if 'train' in scenario or 'MJ1' in scenario or 'IO1' in scenario:
+            continue
+        if scenario in scenario_map:
+            scenario = scenario_map[scenario]
+        text_session_id = entry.get('dreSessionId') if (eval_num != 4 and 'DryRun' in scenario) else entry.get('combinedSessionId') if 'DryRun' in scenario else entry.get('serverSessionId')
+        if not text_session_id:
+            print(f'\033[93mWarning: No server session id found for {pid} {scenario}\033[0m', flush=True)
+            continue
+        sys.stdout.write(f"\rComputing comparison and matches on {scenario} for {pid} (entry {idx} out of {text_count})              ")
+        sys.stdout.flush()
+        # we need no_cursor_timeout because there are a lot of server calls, and the mongo cursor will time out otherwise
+        relevant_adms = adms.find({'evalNumber': eval_num, 'scenario': scenario}, no_cursor_timeout=True)
+        for adm in relevant_adms:
+            score = None
+            adm_session_id = adm['history'][-1]['parameters']['session_id']
+            adm_target = adm['alignment_target']
+            found_count = matches_collection.count_documents({
+                'pid': pid,
+                'probe_subset': False,
+                'text_scenario': scenario,
+                'adm_alignment_target': adm_target,
+                'adm_name': adm['adm_name'],
+                'evalNumber': eval_num
+            })
+            if found_count == 0:
+                # do not rerun a match that has already been calculated
+                matches = calculate_matches(entry, adm, 'Moral judgement' if 'Moral' in adm_target else 'Ingroup Bias' if 'Ingroup' in adm_target else None)
+                matches_collection.insert_one({
+                    'pid': pid,
+                    'probe_subset': False,
+                    'score': matches,
+                    'text_scenario': scenario,
+                    'adm_alignment_target': adm_target,
+                    'adm_name': adm['adm_name'],
+                    'evalNumber': eval_num
+                })
+            # do not rerun a comparison calculation that has already been completed
+            found_count = comparisons.count_documents({
+                'pid': pid,
+                'probe_subset': False,
+                'scenario': scenario,
+                'text_session_id': text_session_id,
+                'adm_session_id': adm_session_id,
+                'adm_name': adm['adm_name'],
+                'adm_alignment_target': adm_target,
+                'evalNumber': eval_num
+            })
+            if found_count > 0:
+                continue
+            if 'DryRun' not in scenario:
+                # create ST query param
+                query_param = f"session_1={text_session_id}&session_2={adm_session_id}"
+                for probe_id in ST_PROBES[scenario]:
+                    query_param += f"&session1_probes={probe_id}"
+                for probe_id in ST_PROBES[scenario]:
+                    query_param += f"&session2_probes={probe_id}"
+                # get comparison score
+                res = requests.get(f'{ST_URL}api/v1/alignment/session/subset?{query_param}').json()
+                score = res['score']
+            else:
+                res = requests.get(f'{ADEPT_URL}api/v1/alignment/compare_sessions?session_id_1={text_session_id}&session_id_2={adm_session_id}').json()
+                score = res['score']
+            comparisons.insert_one({
+                'pid': pid,
+                'probe_subset': False,
+                'scenario': scenario,
+                'text_session_id': text_session_id,
+                'adm_session_id': adm_session_id,
+                'adm_name': adm['adm_name'],
+                'adm_alignment_target': adm_target,
+                'evalNumber': eval_num,
+                'score': score
+        })
+        relevant_adms.close()
+    relevant_text.close()
+    print(f'\033[36mFinished comparison-finding for eval {eval_num}\033[0m', flush=True)
+
+
+def calculate_matches(text, adm, attribute):
+    '''
+    Look through probes of text scenario and adm to count how many
+    responses match.
+    '''
+    MJ_PROBES = {
+        "MJ2": ["Probe 2", "Probe 2A-1", "Probe 2B-1", "Probe 3-B.2", "Probe 5", "Probe 5-A.1", "Probe 5-B.1", "Probe 6", "Probe 7"],
+        "MJ4": ["Probe 1", "Probe 2 kicker", "Probe 2 passerby", "Probe 2-A.1", "Probe 2-D.1", "Probe 2-D.1-B.1", "Probe 3", "Probe 3-A.1", "Probe 3-B.1", "Probe 7", "Probe 8", "Probe 9", "Probe 10", "Probe 10-A.1", "Probe 10-A.1-B.1", "Probe 10-B.1", "Probe 10-C.1"],
+        "MJ5": ["Probe 1", "Probe 1-A.1", "Probe 1-B.1", "Probe 2", "Probe 2-A.1-A.1", "Probe 2-A.1-B.1-A.1", "Probe 2-B.1-A.1", "Probe 2-B.1-B.1-A.1", "Probe 4", "Probe 8-A.1"]
+    }
+    IO_PROBES = {
+        "MJ2": ["Probe 4", "Probe 4-B.1", "Probe 4-B.1-B.1", "Probe 8", "Probe 9", "Probe 9-A.1", "Probe 10", "Probe 9-B.1"],
+        "MJ4": ["Probe 6", "Probe 7", "Probe 8", "Probe 10"],
+        "MJ5": ["Probe 7", "Probe 8", "Probe 8-A.1", "Probe 8-A.1-A.1", "Probe 9", "Probe 9-A.1", "Probe 9-B.1", "Probe 9-C.1"]
+    }
+    scenario_id = text.get('scenario_id')
+    ALLOWED_PROBES = MJ_PROBES if attribute == 'Moral judgement' else IO_PROBES if attribute == 'Ingroup Bias' else None
+    if ALLOWED_PROBES is not None:
+        ALLOWED_PROBES = ALLOWED_PROBES['MJ2' if 'MJ2' in scenario_id else 'MJ4' if 'MJ4' in scenario_id else 'MJ5']
+    adm_probes = []
+    for x in adm['history']:
+        if x['command'] == 'Respond to TA1 Probe':
+            adm_probes.append(x['parameters'])
+    text_probes = []
+    for page in text:
+        if type(text[page]) == dict:
+            if 'questions' in text[page]:
+                for valid_key in [f'probe {page}', f'probe {page}_conditional']:
+                    probe_data = text[page]['questions'].get(valid_key, {})
+                    if 'response' in probe_data:
+                        resp = probe_data['response'].replace('.', '')
+                        if 'question_mapping' in probe_data:
+                            q_map = probe_data['question_mapping']
+                            text_probes.append(q_map[resp])
+
+    matches = 0
+    total = 0
+    # only count probes that both the participant and adm answered (Jennifer's instruction - remind her!)
+    for p1 in text_probes:
+        for p2 in adm_probes:
+            if p1['probe_id'] == p2['probe_id']:
+                if ALLOWED_PROBES is None or (p1['probe_id'] in ALLOWED_PROBES or (p1['choice'] in ALLOWED_PROBES and p2['choice'] in ALLOWED_PROBES)):
+                    total += 1
+                    if p1['choice'] == p2['choice']:
+                        matches += 1
+
+    return matches / max(1, total)

--- a/scripts/_0_5_4_ph1_adms_to_dre_server.py
+++ b/scripts/_0_5_4_ph1_adms_to_dre_server.py
@@ -1,0 +1,37 @@
+from decouple import config 
+import requests
+
+
+DRE_URL = config("ADEPT_DRE_URL")
+
+def main(mongoDB):
+    '''Populates the DRE server with ALL ADEPT adms'''
+    all_adms = mongoDB['test']
+    adept_adms = all_adms.find({'evalNumber': 5, 'scenario': {'$regex': 'DryRunEval'}})
+
+    for adm in adept_adms:
+        # start new adept session
+        adept_sid = requests.post(f'{DRE_URL}api/v1/new_session').text.replace('"', '').strip()
+        probe_responses = []
+        for x in adm['history']:
+            if x['command'] == 'Respond to TA1 Probe':
+                probe_responses.append(x['parameters'])
+        send_probes(probe_responses, adept_sid)
+        history = adm['history']
+        history[-1]['parameters']['dreSessionId'] = adept_sid
+        all_adms.update_one({'_id': adm['_id']}, {'$set': {'history': history}})
+
+
+    print("All Phase 1 ADMs sent to ADEPT DRE server - dreSessionIds added.")
+        
+def send_probes(probe_responses, adept_sid):
+    for x in probe_responses:
+        requests.post(f'{DRE_URL}api/v1/response', json={
+            "response": {
+                "choice": x['choice'],
+                "justification": x["justification"],
+                "probe_id": x['probe_id'],
+                "scenario_id": x['scenario_id'],
+            },
+            "session_id": adept_sid
+        })


### PR DESCRIPTION
To run, run the deployment script. There are three new scripts:

The first (053) sends the january eval data to the DRE server. 

The second (054) sends all ADEPT phase 1 ADMs to the DRE server (not subsets of probes - full probe responses)

The third (055) runs every single participant's text responses from DRE, PH1, and JAN against every single ADM with the same scenario. This uses the ADEPT DRE comparison endpoint every time, while ST changes based on DRE vs PH1/JAN. It also runs the percent-probe-match script (what percent of the time did the ADM and human choose the same probe response). 

The special thing about this, aside from it being every single combination of target/adm/human per scenario, is that we are not taking a subset of probes this time. 

This takes forever to run, because every text scenario gets compared against all 4 adms across all the targets for that scenario (which could be anywhere between 8-16, or something like that. Group targets are included). It would be difficult to run locally (as in, with local TA1 servers) because you'd need to run the proper other scripts first to populate your local database with all the correct session ids, but it is doable. Feel free to do this if you'd like. If not, be prepared to wait a full business day for the script to finish. 

A csv (full_probe_comparrisons.csv) is outputted with the data from the third script.

NOTE: Right now, the third script is only running Eval 5 (PH1), per Jennifer's request


There is a possibility your mongo cursor will time out during this process. I have tried to put precautions in place so this will not happen, but it doesn't seem to always work. If it times out, run it again - the script skips everything that has already been run and will continue from where it left off