### PR TITLE
Added script for dre alignment on ph1 adept adms

### DIFF
--- a/scripts/_0_6_1_dre_adm_alignment_adept.py
+++ b/scripts/_0_6_1_dre_adm_alignment_adept.py
@@ -16,12 +16,19 @@ def main(mongoDB):
         history = adm['history']
         dre_session_id = history[-1]['parameters'].get('dreSessionId')
         target = adm["alignment_target"]
+        if "-Group-" in target:
+            continue
         if dre_session_id is None:
             print(f'Error getting dre session id from {adm["adm_name"]} - {adm["scenario"]} - {target}')
             continue
         
         # dre version of alignment score
         alignment = requests.get(f'{DRE_URL}api/v1/alignment/session?session_id={dre_session_id}&target_id={target}&population=false').json()
+
+        if 'score' not in alignment:
+            print(f'Error getting dre alignment from {adm["adm_name"]} - {adm["scenario"]} - {target} with dre session id {dre_session_id}')
+            continue
+        
         
         history[-1]['response']['dre_alignment'] = alignment
         all_adms.update_one({'_id': adm['_id']}, {'$set': {'history': history}})

--- a/scripts/_0_6_1_dre_adm_alignment_adept.py
+++ b/scripts/_0_6_1_dre_adm_alignment_adept.py
@@ -1,0 +1,31 @@
+# _0_5_4 sends all phase 1 adms (ADEPT only) to the DRE server
+# this gets the alignment using those session ids and stores it in the db
+
+from decouple import config 
+import requests
+
+
+DRE_URL = config("ADEPT_DRE_URL")
+
+def main(mongoDB):
+    '''Populates the DRE server with ALL ADEPT adms'''
+    all_adms = mongoDB['admTargetRuns']
+    adept_adms = all_adms.find({'evalNumber': 5, 'scenario': {'$regex': 'DryRunEval'}})
+
+    for adm in adept_adms:
+        history = adm['history']
+        dre_session_id = history[-1]['parameters'].get('dreSessionId')
+        target = adm["alignment_target"]
+        if dre_session_id is None:
+            print(f'Error getting dre session id from {adm["adm_name"]} - {adm["scenario"]} - {target}')
+            continue
+        
+        # dre version of alignment score
+        alignment = requests.get(f'{DRE_URL}api/v1/alignment/session?session_id={dre_session_id}&target_id={target}&population=false').json()
+        
+        history[-1]['response']['dre_alignment'] = alignment
+        all_adms.update_one({'_id': adm['_id']}, {'$set': {'history': history}})
+
+
+    print("ADEPT Phase 1 ADMs now have DRE alignment score attached.")
+        


### PR DESCRIPTION
Task: Add script that will run each ADM/Target for the ADEPT Scenarios against the DRE endpoint, and add a field to the record so that both the P1E alignment score is there, with the additional DRE alignment score

We had already run each ADM for the ADEPT scenarios (ph1) against the DRE endpoint in 054. We had stored the dresessionids, so just needed to grab those and get the alignment using the DRE endpoint. 

The alignment is stored next to the ph1 alignment in the last history index. Check mongo to see that dre_alignment appears for these adms.

Working on a dashboard PR now to visualize this. Draft until it's done

Run the deployment script. You should not get any errors. (Note: this will not get the alignment for group targets)