### PR TITLE
update script no.

### DIFF
--- a/scripts/_0_6_3_fix_jan_comparisons.py
+++ b/scripts/_0_6_3_fix_jan_comparisons.py
@@ -189,6 +189,7 @@ def mini_adm_run_fixed(mongo_db, pid, scenario, adm_name, target, problem_probes
     if res_json is not None and 'score' in res_json:
         updated_doc = original_doc.copy()
         updated_doc['score'] = res_json['score']
+        print('hit truncation error update')
         updated_doc['truncation_error'] = True
         updated_doc['adm_session_id'] = adept_sid
         return updated_doc

--- a/scripts/_0_6_3_fix_jan_comparisons.py
+++ b/scripts/_0_6_3_fix_jan_comparisons.py
@@ -189,7 +189,6 @@ def mini_adm_run_fixed(mongo_db, pid, scenario, adm_name, target, problem_probes
     if res_json is not None and 'score' in res_json:
         updated_doc = original_doc.copy()
         updated_doc['score'] = res_json['score']
-        print('hit truncation error update')
         updated_doc['truncation_error'] = True
         updated_doc['adm_session_id'] = adept_sid
         return updated_doc


### PR DESCRIPTION
[Original PR](https://github.com/NextCenturyCorporation/itm-ingest/pull/111)
This script uses `pandas` and we hadn't re-installed requirements.txt on prod so it failed. To test locally we need to wipe away the effects the script previously had. I did this by just deleting my Mongo container and rebuilding/populating with a backup. My backup was set to version 0.5.8 (Message me if you want me to send it). Then just run deployment script as usual and make sure you can see the effects in the RQ1 table for Jan Eval. I've attached what the data should look like.

Relevant Columns:
```
Alignment score   (Delegator\|Observed_ADM (target)) 
DRE Alignment score (Delegator\|Observed_ADM   (target))
Truncation Error
```
The rename is just a hacky fix so that we can run it on prod with just `python deployment_script.py` without having to change anything else. Will explore better error handling for the deployment script so we can avoid stuff like this in the future. 
EDIT:
[RQ-134 data (5).xlsx](https://github.com/user-attachments/files/19438444/RQ-134.data.5.xlsx)

