### PR TITLE
Itm 929

### DIFF
--- a/scripts/_0_6_7_cleanup_adm_results.py
+++ b/scripts/_0_6_7_cleanup_adm_results.py
@@ -1,0 +1,23 @@
+remove_adm = 'ALIGN-ADM-RelevanceComparativeRegression-ADEPT__4e570b6d-8f9e-4e3c-8d0f-ffcde73a5792'
+relevance = 'ALIGN-ADM-RelevanceComparativeRegression-ADEPT'
+comparative = 'ALIGN-ADM-ComparativeRegression-ADEPT'
+def main(mongo_db):
+    adm_collection = mongo_db['admTargetRuns']
+    eval_7_adms = adm_collection.find({'evalNumber': 7})
+
+    for adm in eval_7_adms:
+        if adm['adm_name'] == remove_adm:
+            # remove the extra adm results from mj2
+            adm_collection.delete_one({'_id': adm['_id']})
+        # remove the uuid portion of the adm names
+        elif relevance in adm['adm_name']:
+            adm_collection.update_one(
+                {'_id': adm['_id']},
+                {'$set': {'adm_name': relevance}}
+            )
+        elif comparative in adm['adm_name']:
+            adm_collection.update_one(
+                {'_id': adm['_id']},
+                {'$set': {'adm_name': comparative}}
+            )
+        

--- a/scripts/_0_6_7_cleanup_adm_results.py
+++ b/scripts/_0_6_7_cleanup_adm_results.py
@@ -9,6 +9,7 @@ def main(mongo_db):
         if adm['adm_name'] == remove_adm:
             # remove the extra adm results from mj2
             adm_collection.delete_one({'_id': adm['_id']})
+            continue
         # remove the uuid portion of the adm names
         elif relevance in adm['adm_name']:
             adm_collection.update_one(
@@ -20,4 +21,36 @@ def main(mongo_db):
                 {'_id': adm['_id']},
                 {'$set': {'adm_name': comparative}}
             )
+        
+        # go through history and clean adm names
+        for i, history_entry in enumerate(adm['history']):
+                if 'parameters' in history_entry and 'adm_name' in history_entry['parameters']:
+                    param_adm_name = history_entry['parameters']['adm_name']
+                    if relevance in param_adm_name:
+                        update_field = f'history.{i}.parameters.adm_name'
+                        adm_collection.update_one(
+                            {'_id': adm['_id']},
+                            {'$set': {update_field: relevance}}
+                        )
+                    elif comparative in param_adm_name:
+                        update_field = f'history.{i}.parameters.adm_name'
+                        adm_collection.update_one(
+                            {'_id': adm['_id']},
+                            {'$set': {update_field: comparative}}
+                        )
+    multi_kdma_collect = mongo_db['multiKdmaData']
+    multi_kdma_collect.delete_many({'admName': remove_adm})
+    multi_kdma_docs = multi_kdma_collect.find({})
+    for doc in multi_kdma_docs:
+        if 'admName' in doc:
+            if relevance in doc['admName']:
+                multi_kdma_collect.update_one(
+                    {'_id': doc['_id']},
+                    {'$set': {'admName': relevance}}
+                )
+            elif comparative in doc['admName']:
+                multi_kdma_collect.update_one(
+                    {'_id': doc['_id']},
+                    {'$set': {'admName': comparative}}
+                )
         


### PR DESCRIPTION
This removes the 3rd ADM results for MJ2 that did not run the other scenarios `ALIGN-ADM-RelevanceComparativeRegression-ADEPT__4e570b6d-8f9e-4e3c-8d0f-ffcde73a5792`. It removes the uuid string from the ADM names on the top level and in the history array. It also tidies the ADM names in the `multiKdmaData` collection as well. 

`python deployment_script.py` 

Check [dashboard pr](https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/275)