### PR TITLE
added script to update earlier ta1 session ids in adm history

### DIFF
--- a/scripts/_0_7_0_fix_adm_session_ids.py
+++ b/scripts/_0_7_0_fix_adm_session_ids.py
@@ -1,0 +1,19 @@
+def main(mongo_db):
+    adms = mongo_db['admTargetRuns']
+    eval5_adms = adms.find({'evalNumber': 5})
+    for adm in eval5_adms:
+        # get most up-to-date ta1 session id
+        ta1_session_id = adm['history'][-1]['parameters']['session_id']
+        history = adm['history']
+        found = 0
+        for x in history:
+            if x['command'] == "TA1 Session ID":
+                x['response'] = ta1_session_id
+                found += 1
+            if x['command'] == 'Alignment Target':
+                x['parameters']['session_id'] = ta1_session_id
+                found += 1
+            if found == 2:
+                break
+        adms.update_one({'_id': adm['_id']}, {'$set': {'history': history}})
+


### PR DESCRIPTION
We had updated ADEPT and apparently ST ADM session ids at some point in time. We changed the session id value in the last `history` entry in `admTargetRuns`, but the TA1 session id also appears in a TA1 Session ID entry and an Alignment Target entry in `history`. Those were not changed. The TA1 Session ID entry was being used to populate the dashboard probe responses page, causing mismatches in data, with the dashboard showing outdated information. 

This script makes sure both of these earlier fields in history are updated to match the correct TA1 session id, found in the last `history` element. 

Run, and check the dashboard and database to see that all three TA1 session ids match. 