### PR TITLE
Clean test runs from 4/21

### DIFF
--- a/scripts/_0_7_2_wipe_test_data.py
+++ b/scripts/_0_7_2_wipe_test_data.py
@@ -1,3 +1,7 @@
+'''
+Any day where we have a lot of testing before a data collection, this script can be tweaked and run to wipe
+away the noisy data. 
+'''
 def main(mongo_db):
     survey_results = mongo_db['surveyResults']
 

--- a/scripts/_0_7_2_wipe_test_data.py
+++ b/scripts/_0_7_2_wipe_test_data.py
@@ -1,0 +1,14 @@
+def main(mongo_db):
+    survey_results = mongo_db['surveyResults']
+
+    start_date = "Mon Apr 21 2025 00:00:00 GMT-0400 (Eastern Daylight Time)"
+    end_date = "Mon Apr 21 2025 23:59:59 GMT-0400 (Eastern Daylight Time)"
+
+    delete_result = survey_results.delete_many({
+        "$or": [
+            {"results.timeComplete": {"$gte": start_date, "$lte": end_date}},
+            {"results.startTime": {"$gte": start_date, "$lte": end_date}}
+        ]
+    })
+
+    print(f"Deleted {delete_result.deleted_count} entries from April 21st, 2025")


### PR DESCRIPTION
`python deployment_script.py`

If you grab a copy of the prod database, this script should delete yesterday's two survey test runs. Check localhost:3000/survey-results under legacy and survey version 1.3 to see the change go into effect. 

This script can be tweaked in the future if there are any heavy testing days. All that needs to be changed is the `start_date` and `end_date` variables