### PR TITLE
Results.pid

### DIFF
--- a/scripts/_0_7_3_results_pid.py
+++ b/scripts/_0_7_3_results_pid.py
@@ -1,0 +1,50 @@
+'''
+We started placing the pid towards the top level of survey results documents `results.pid`
+This retroactively applies that to older documents 
+Makes it easier for future processing of survey data
+ALSO, this script deletes garbage documents that were added to this collection by cyber a while back (around MRE time)
+'''
+def main(mongo_db):
+    survey_results = mongo_db["surveyResults"]
+
+    query = {
+        "results": {"$exists": True},
+        "$or": [
+            {"evalNumber": {"$gte": 3}},
+            {"results.evalNumber": {"$gte": 3}}
+        ]
+    }
+
+    surveys = survey_results.find(query)
+
+    for survey in surveys:
+        if "results" in survey and not isinstance(survey["results"], dict):
+            # deletes cyber inserted noise from db
+            survey_results.delete_one({"_id": survey["_id"]})
+            continue
+        try:
+            if "Participant ID Page" in survey["results"]:
+                participant_id_page = survey["results"]["Participant ID Page"]
+            elif "Participant ID" in survey["results"]:
+                # some very old (1.1 1.2) data has a different page name
+                participant_id_page = survey["results"]["Participant ID"]
+            else:
+                continue
+
+
+            if isinstance(participant_id_page["questions"], list):
+                # some invalid incomplete documents
+                continue
+            else:
+                pid = participant_id_page["questions"]["Participant ID"]["response"]
+
+
+            # most from eval 5 onward have it already
+            if "pid" not in survey["results"]:
+                survey_results.update_one(
+                    {"_id": survey["_id"]},
+                    {"$set": {"results.pid": pid}}
+                )
+        except KeyError:
+            # dont need to do anything, just means that survey doesnt have that field (incomplete or old)
+            pass


### PR DESCRIPTION
[Ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?assignee=60ba425da547eb00686ee0ce&selectedIssue=ITM-972)

Kaitlyn and I added the pid to `surveyResults` documents closer to the root level sometime during Phase 1 (`results.pid`). This script will go back through older results and do the same thing for them, making it easier to process them in future ingest tasks. This does not remove the pid from its original location, so anything that points to the previous location on the dashboard will remain unchanged. I also deleted any garbage documents from the collection that were added by cyber. 

`python deployment_script.py`

Then click through some older survey results in Mongo Compass to see that `results.pid` exists