### PR TITLE
Clean up testing on prod

### DIFF
--- a/scripts/_0_7_7_p2_clean_text_testing.py
+++ b/scripts/_0_7_7_p2_clean_text_testing.py
@@ -1,0 +1,12 @@
+def main(mongo_db):
+    pids = ['202506100', '202506101', '202506102', '202506103']
+    p_log = mongo_db['participantLog']
+    text_based = mongo_db['userScenarioResults']
+    
+    pids_as_numbers = [int(pid) for pid in pids]
+    
+    result_p_log = p_log.delete_many({'ParticipantID': {'$in': pids_as_numbers}})
+    print(f"Deleted {result_p_log.deleted_count} documents from participantLog")
+    
+    result_text_based = text_based.delete_many({'participantID': {'$in': pids}})
+    print(f"Deleted {result_text_based.deleted_count} documents from userScenarioResults")


### PR DESCRIPTION
ITM 1013

Small script that cleans up the `participantLog` and `userScenarioResults`

`python deployment_script.py`

You can check with Mongo Compass or http://localhost:3000/participant-progress-table to verify the records have been deleted. 

Note: This is based on the backup I grabbed earlier. Tomorrow morning, before standup, I will grab the newer one in case someone else tested after I made the backup.  