### PR TITLE
ITM 1030

### DIFF
--- a/scripts/_0_8_0_clean_p2_test_adms.py
+++ b/scripts/_0_8_0_clean_p2_test_adms.py
@@ -1,0 +1,16 @@
+'''
+Removes test adms runs from database
+'''
+def main(mongo_db):
+    adm_collec = mongo_db['admTargetRuns']
+    
+    delete_result = adm_collec.delete_many({
+        "evalNumber": 8,
+        "$or": [
+            {"adm_name": {"$regex": "test", "$options": "i"}},  
+            {"adm_name": {"$regex": "Random", "$options": "i"}},
+            {"adm_name": {"$regex": "6d0829ad-4e3c-4a03-8f3d-472cc549888f"}}  
+        ]
+    })
+    
+    print(f"Deleted {delete_result.deleted_count} documents from admTargetRuns collection")


### PR DESCRIPTION
http://localhost:3000/results

You'll see some test results polluting our data. After running:

`python deployment_script.py` 

all of these test runs should be removed. 

Known test runs were any adm names that included `test`, `random`, or `6d0829ad-4e3c-4a03-8f3d-472cc549888f`
