### PR TITLE
Redo.py can pass an argument from the command line

### DIFF
--- a/scripts/_0_8_3_June_Collab_Comparison_Generation.py
+++ b/scripts/_0_8_3_June_Collab_Comparison_Generation.py
@@ -12,7 +12,7 @@ def main(mongoDB, EVAL_NUMBER=8):
     comparison_collection = mongoDB['humanToADMComparison']
     
     # Let's you rerun script when necessary to repopulate as more participants come in
-    comparison_collection.delete_many({"evalNumber": 8})
+    comparison_collection.delete_many({"evalNumber": EVAL_NUMBER})
     medic_collection = mongoDB['admMedics']
     adm_collection = mongoDB["admTargetRuns"]
 
@@ -25,7 +25,7 @@ def main(mongoDB, EVAL_NUMBER=8):
     )
     current_text_scenario = 1
     for entry in data_to_use:
-        print(f"Currently processing {current_text_scenario} of {total_text_scenarios} total text scenarios Evaluation 8.")
+        print(f"Currently processing {current_text_scenario} of {total_text_scenarios} total text scenarios Evaluation {EVAL_NUMBER}.")
         current_text_scenario += 1
 
         scenario_id = entry.get('scenario_id')


### PR DESCRIPTION
I realized that there are certain instances where we will need to be able to pass an argument when running `redo.py`. For example, script `083` generated the June comparison scores for delegators against the observed ADMS. That script has an `EVAL_NUMBER` parameter (with default value of 8), but will work the same for eval number 9. In this case, we can use our Jenkins job for the redo script, but it needs to be capable of passing a new `EVAL_NUMBER`.

Changes: 
- Minor tweak to `083` in a few spots that had eval number 8 hard-coded. 
- redo.py can take additional arguments from the command line
- redo.py determines what type the argument should be treated as (int, float, bool, string)

A quick way to test this would be to run `python redo.py 083 9`. The redo script should identify that we need to run script 083, and then pass 9 (as an int) as the `EVAL_NUMBER`. You should then be able to check `humanToADMComparison` with  `{ evalNumber: 9 }` and see documents that were not previously there. Let me know if you need the latest db backup to test this.

Note: Jenkins job update accompanies this, but is not part of reviewing this pr. 