### PR TITLE
added treatment logger script for open world scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ adept-evals/eval4/*.json
 adept-evals/eval4/*.py
 
 dev_scripts/*.csv
+
+treatment_counts.csv
+treatments_per_patient.csv

--- a/dev_scripts/treatment_logger.py
+++ b/dev_scripts/treatment_logger.py
@@ -53,7 +53,7 @@ class TreatmentLogger:
         Call after all update_logger_from_json calls are complete.
         Generates a csv that organizes the treatment data.
         '''
-        f = open('number_of_people_who_treated_each_patient_with_treatment.csv' if not total else 'total_treatments_per_patient.csv', 'w', encoding='utf-8')
+        f = open('treatment_counts.csv' if not total else 'treatments_per_patient.csv', 'w', encoding='utf-8')
         writer = csv.writer(f)
         inverted = {}
         treatments = []
@@ -71,7 +71,6 @@ class TreatmentLogger:
                     inverted[formattedTreatment][patient] = 0
                 inverted[formattedTreatment][patient] += dict_to_use[patient][treatment]
         treatments.sort()
-        print(json.dumps(inverted, indent=4))
 
         header.insert(0, 'Treatment')
         writer.writerow(header)


### PR DESCRIPTION
Run `python dev_scripts/treatment_logger.py -i ph2_sim_files`

There will be two output csv files, formatted the same way. 
- The columns are for each patient
- The rows describe the treatment, location, and applicable injury
- In `treatment_counts.csv`, the cells are the number of participants who treated the patient with the treatment
- In `treatments_per_patient.csv`, the cell describes how many of that treatment in total were given to the patient. This includes duplicate treatments by the same participant

The two files will be nearly identical and only differ when participants gave many of the same treatment to the same patient.