### PR TITLE
ITM 1075: Resolve Field Visibility Errors in Delegation Survey

### DIFF
--- a/scripts/_0_8_8_fix_delegation_survey_visibility.py
+++ b/scripts/_0_8_8_fix_delegation_survey_visibility.py
@@ -77,7 +77,15 @@ def main(mongo_db):
                     modified = True
             else:
                 print(f"Unexpected name at element {index} in {doc.get('_id')}: '{name}'")
-
+        
+        #Bug C: Last TCCC Question in Survey Should Be Required
+        if len(elements) > 22:
+            element22 = elements[22]
+            if element22.get("name") == "How many real-world casualties have you assessed using TCCC protocols":
+                if element22.get("isRequired") is not True:
+                    element22["isRequired"] = True
+                    modified = True
+    
         if modified:
             delegation_collection.update_one(
                 {"_id": doc["_id"]},


### PR DESCRIPTION
**Original Ticket:** [Here](https://nextcentury.atlassian.net/browse/ITM-1075?atlOrigin=eyJpIjoiMjYzMTM4OTg0MDgxNDUyOWE2MzM2M2E3NmFiOWZhMGQiLCJwIjoiaiJ9)

## Description: 
This PR resolves an edge case in the participant delegation survey reported by @nextcen-dgemoets. Originally, when clicking through the last page (Post-Scenario Measures page) of the delegation survey, leaving a required field that was generated by a particular set of answers to the `What is your current role? (choose all that apply): *` question empty would result in the field being required (and hence appearing in red if a user tried to submit the survey without completion of this form). When the user then changed their answer to a response that shouldn't trigger that follow up field, the field remained and was required for form submission. Further, through manual testing and inspection of the survey config JSON to see if similar bugs exist, I found that if a particular branch of question responses were provided, then follow-up survey questions would remain, even if previous questions that eliminated the necessity for these fields remained. The particular branch of questions where this occurs is shown below:
1. Answer anything besides `Never Served` to `Are you currently or have you previously served in the military? *`
2. Answer `Yes` to `Did you serve in a military medical role? *`
3. Answer anything besides `Never completed` to `When did you last complete TCCC training or recertification? *`

This branch provides a new ingest script (`_0_8_8_fix_delegation_survey_visibility.py`) to patch survey JSON config documents located in the `delegationConfig` collection of the database, resolving both of these issues. These changes apply to both version 7 and version 6 of the survey (which both contained the same configuration layout). In addition, I noticed that the `What is your role?` question instructed users to "choose all that apply", however only one option could be selected. I converted this question to multi-select so users can pick multiple roles, fulfilling the intention of the question. 

## Disclaimers
1. I attempted to check existing downstream logic in the code base that accesses the participant's response to the `What is your current role?` question, since now more than one choice can be selected, which changes the response to an array of choices as opposed to a string. I believe that the existing implementation of reliant files such as `DataFunctions.js` and `aggregateResults.jsx` already treats the response to this question as an array, so I don't anticipate that anything downstream breaking. I'd appreciate confirmation on this if possible @dereknop and @kaitlyn-sharo.
2. Right now, the indices of elements that are changed within specific arrays in the delegation survey config documents are hardcoded. I reasoned that this would be the best approach, considering that it significantly reduces the time complexity of looping through each element of each page of each delegation configuration document to a linear time `O(n)` operation where `n` represents the number of documents in the delegation config collection. However, this is less future proof and requires far more assumptions about the existing config JSON structure. @dereknop, please let me know if you would prefer I revert to a brute force lookup, which will be more dynamic but significantly slower to deploy. 

## How to Test
**TIP:** Use a random or non-existent PID when starting the survey (e.g., manually type a gibberish PID) so that text scenario data does not load. This shortcut lets you jump faster to the “Post-Scenario Measures” page of the survey without having to click through the scenario medic pages.
1. Run the Ingest deployment script using `python deployment_script.py.` Confirm from the logs printed to the terminal that there were no errors as the script updated your configuration information. 
2. Restart your Docker containers as a precaution.
3. Open the delegation survey here: http://localhost:3000/survey. Click through to the last page (Post-Scenario measures).  Navigate to the “What is your current role” question. Ensure that you can now select multiple options instead of just one.
4. Select a role (not “Other”), leave the follow-up blank and attempt to progress to completing the survey — verify that it’s required for completion.  
5. Switch to “Other (please specify)” and confirm the follow-up comment disappears and is no longer required.
6. Switch back to a non-“Other” role and verify the follow-up reappears and is required exactly as expected.  
7. Next, navigate to the question `Are you currently or have you previously served in the military? *`. Answer `Yes` to `Did you serve in a military medical role?`, and choose a TCCC training answer other than `Never completed` to expose deeper follow-ups.  Then change upstream answers in two ways:  
     a. Change “Did you serve in a military medical role?” to `No` and confirm all deeper follow-up questions (including TCCC-related ones) disappear and are not required. Next, switch it back to `Yes`. 
     b. Change “Are you currently or have you previously served in the military?” to `Never Served` and ensure all downstream questions in that branch (including the medical role and TCCC-related ones) are hidden and not required.  
8. Fill out the entire survey end-to-end, ensuring that you can submit successfully without any errors.
9. Go to the administrator tab here: http://localhost:3000/admin. Change your survey version to 6 and repeat steps 3 - 8.