### PR TITLE
Repopulation and Comparison scores

### DIFF
--- a/ph2_repop.py
+++ b/ph2_repop.py
@@ -14,14 +14,6 @@ import utils.db_utils as db_utils
 MONGO_URL = config("MONGO_URL")
 ADEPT_URL = config("ADEPT_URL")
 
-import requests
-from decouple import config
-from collections import defaultdict
-import utils.db_utils as db_utils
-
-MONGO_URL = config("MONGO_URL")
-ADEPT_URL = config("ADEPT_URL")
-
 
 def main(mongo_db):
    text_scenarios = mongo_db["userScenarioResults"].find({"evalNumber": {"$gte": 8}})

--- a/ph2_repop.py
+++ b/ph2_repop.py
@@ -1,0 +1,126 @@
+"""
+https://nextcentury.atlassian.net/browse/ITM-1085
+
+This script takes all text based scenario results and adm runs of eval number 8 or greater
+and repopulates the ADEPT server with the probe responses. This script is to be used if the
+ADEPT server is not persisting session ids that are needed to generate comparison scores.
+"""
+
+import requests
+from decouple import config
+from collections import defaultdict
+import utils.db_utils as db_utils
+
+MONGO_URL = config("MONGO_URL")
+ADEPT_URL = config("ADEPT_URL")
+
+
+def main(mongo_db):
+    text_scenarios = mongo_db["userScenarioResults"].find({"evalNumber": {"$gte": 8}})
+    adm_medics = mongo_db["admMedics"].find({"evalNumber": {"$gte": 8}})
+    adm_runs = mongo_db["admTargetRuns"].find({"evalNumber": {"$gte": 8}})
+
+    # group text scenarios by pid
+    participant_groups = defaultdict(list)
+    for result in text_scenarios:
+        participant_groups[result["participantID"]].append(result)
+
+    for participant_id, documents in participant_groups.items():
+        print(
+            f"Processing participant {participant_id} with {len(documents)} documents"
+        )
+
+        if len(documents) != 4:
+            print(
+                f"Warning: Participant {participant_id} has {len(documents)} documents instead of 4"
+            )
+            continue
+
+        # creates new session id and responds to all probes using it
+        sid = (
+            requests.post(f"{ADEPT_URL}api/v1/new_session")
+            .text.replace('"', "")
+            .strip()
+        )
+        for document in documents:
+            probes = []
+            for key, value in document.items():
+                if isinstance(value, dict) and "questions" in value:
+                    probe = value["questions"].get(f"probe {key}", {})
+                    response = probe.get("response", "").replace(".", "")
+                    mapping = probe.get("question_mapping", {})
+                    if response in mapping:
+                        probes.append(
+                            {
+                                "probe": {
+                                    "choice": mapping[response]["choice"],
+                                    "probe_id": mapping[response]["probe_id"],
+                                }
+                            }
+                        )
+            db_utils.send_probes(
+                f"{ADEPT_URL}api/v1/response", probes, sid, document["scenario_id"]
+            )
+            # update the session id on the text based documents
+            mongo_db["userScenarioResults"].update_one(
+                {"_id": document["_id"]}, {"$set": {"combinedSessionId": sid}}
+            )
+
+    for adm_run in adm_runs:
+        sid = (
+            requests.post(f"{ADEPT_URL}api/v1/new_session")
+            .text.replace('"', "")
+            .strip()
+        )
+        # probably not needed but better to update the admMedics collection as well
+        corresponding_medic = mongo_db["admMedics"].find_one(
+            {"admSessionId": adm_run.get("results", {}).get("ta1_session_id")}
+        )
+
+        probes = []
+        for entry in adm_run["history"]:
+            if entry["command"] == "Respond to TA1 Probe":
+                probe = entry["parameters"]
+                probes.append(
+                    {
+                        "probe": {
+                            "choice": probe["choice"],
+                            "probe_id": probe["probe_id"],
+                        }
+                    }
+                )
+
+        db_utils.send_probes(
+            f"{ADEPT_URL}api/v1/response", probes, sid, document["scenario_id"]
+        )
+        if corresponding_medic:
+            mongo_db["admMedics"].update_one(
+                {"_id": corresponding_medic["_id"]}, {"$set": {"admSessionId": sid}}
+            )
+
+        # updates every reference to the old session id in the adm run document
+        mongo_db["admTargetRuns"].update_one(
+            {"_id": adm_run["_id"]},
+            {
+                "$set": {
+                    "results.ta1_session_id": sid,
+                    "history.$[sessionId].response": sid,
+                    "history.$[probeAlign].parameters.session_id": sid,
+                    "history.$[sessionAlign].parameters.session_id": sid,
+                }
+            },
+            array_filters=[
+                {"sessionId.command": "TA1 Session ID"},
+                {"probeAlign.command": "TA1 Probe Response Alignment"},
+                {"sessionAlign.command": "TA1 Session Alignment"},
+            ],
+        )
+
+
+if __name__ == "__main__":
+    from pymongo import MongoClient
+
+    MONGO_URL = config("MONGO_URL")
+    client = MongoClient(MONGO_URL)
+    mongoDB = client["dashboard"]
+    main(mongoDB)

--- a/ph2_repop.py
+++ b/ph2_repop.py
@@ -82,9 +82,6 @@ def main(mongo_db):
         corresponding_medic = mongo_db["admMedics"].find_one(
             {"admSessionId": old_session_id}
         )
-        
-        if not corresponding_medic:
-            print(f"Warning: No corresponding medic found for session id: {old_session_id}")
 
         probes = []
         for entry in adm_run["history"]:

--- a/scripts/_0_8_3_June_Collab_Comparison_Generation.py
+++ b/scripts/_0_8_3_June_Collab_Comparison_Generation.py
@@ -40,30 +40,30 @@ def main(mongoDB, EVAL_NUMBER=8):
         for page in survey['results']:
             if 'Medic' in page and ' vs ' not in page:
                 page_scenario = survey['results'][page]['scenarioIndex']
-                if ('June2025' in scenario_id):
-                    adm = db_utils.find_adm_from_medic(EVAL_NUMBER, medic_collection, adm_collection, page, page_scenario, survey)
-                    if adm is None:
-                        continue
-                    adm_session = medic_collection.find_one({'evalNumber': EVAL_NUMBER, 'name': page})['admSessionId']
+                adm = db_utils.find_adm_from_medic(EVAL_NUMBER, medic_collection, adm_collection, page, page_scenario, survey)
+                if adm is None:
+                    continue
 
-                    res = requests.get(f'{ADEPT_URL}api/v1/alignment/compare_sessions?session_id_1={session_id}&session_id_2={adm_session}').json()
+                adm_session = medic_collection.find_one({'evalNumber': EVAL_NUMBER, 'name': page})['admSessionId']
 
-                    # send document to mongo
-                    if res is not None and 'score' in res:
-                        document = {
-                            'pid': pid,
-                            'adm_type': survey['results'][page]['admAlignment'],
-                            'score': res['score'],
-                            'text_scenario': scenario_id,
-                            'text_session_id': session_id.replace('"', "").strip(),
-                            'adm_scenario': page_scenario,
-                            'adm_session_id': adm_session,
-                            'adm_alignment_target': survey['results'][page]['admTarget'],
-                            'evalNumber': EVAL_NUMBER
-                        }
-                        send_document_to_mongo(comparison_collection, document)
-                    else:
-                        print(f'Error getting comparison for scenarios {scenario_id} and {page_scenario} with text session {session_id} and adm session {adm_session}', res)
+                res = requests.get(f'{ADEPT_URL}api/v1/alignment/compare_sessions?session_id_1={session_id}&session_id_2={adm_session}').json()
+
+                # send document to mongo
+                if res is not None and 'score' in res:
+                    document = {
+                        'pid': pid,
+                        'adm_type': survey['results'][page]['admAlignment'],
+                        'score': res['score'],
+                        'text_scenario': scenario_id,
+                        'text_session_id': session_id.replace('"', "").strip(),
+                        'adm_scenario': page_scenario,
+                        'adm_session_id': adm_session,
+                        'adm_alignment_target': survey['results'][page]['admTarget'],
+                        'evalNumber': EVAL_NUMBER
+                    }
+                    send_document_to_mongo(comparison_collection, document)
+                else:
+                    print(f'Error getting comparison for scenarios {scenario_id} and {page_scenario} with text session {session_id} and adm session {adm_session}', res)
 
 
     print("Human to ADM comparison values added to database.")

--- a/scripts/_0_8_3_June_Collab_Comparison_Generation.py
+++ b/scripts/_0_8_3_June_Collab_Comparison_Generation.py
@@ -12,7 +12,7 @@ def main(mongoDB, EVAL_NUMBER=8):
     comparison_collection = mongoDB['humanToADMComparison']
     
     # Let's you rerun script when necessary to repopulate as more participants come in
-    comparison_collection.delete_many({"evalNumber": 8})
+    comparison_collection.delete_many({"evalNumber": EVAL_NUMBER})
     medic_collection = mongoDB['admMedics']
     adm_collection = mongoDB["admTargetRuns"]
 
@@ -25,7 +25,7 @@ def main(mongoDB, EVAL_NUMBER=8):
     )
     current_text_scenario = 1
     for entry in data_to_use:
-        print(f"Currently processing {current_text_scenario} of {total_text_scenarios} total text scenarios Evaluation 8.")
+        print(f"Currently processing {current_text_scenario} of {total_text_scenarios} total text scenarios Evaluation {EVAL_NUMBER}.")
         current_text_scenario += 1
 
         scenario_id = entry.get('scenario_id')

--- a/scripts/_0_8_9_ph2_repop_cleanup.py
+++ b/scripts/_0_8_9_ph2_repop_cleanup.py
@@ -1,0 +1,4 @@
+from ph2_repop import main as ph2_repop
+def main(mongo_db):
+    # repopulate ta1 server
+    ph2_repop(mongo_db)

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -67,7 +67,7 @@ def mini_adm_run(evalNumber, collection, probes, target, adm_name, dre_ph1_run=F
 def find_adm_from_medic(eval_number, medic_collection, adm_collection, page, page_scenario, survey):
     if eval_number == 5 or eval_number == 6:
         page_scenario = PH1_SCENARIO_MAP[page_scenario]
-    ADM_SESSION_VAR_NAME = 'admSessionId' if eval_number == 8 else 'admSession'
+    ADM_SESSION_VAR_NAME = 'admSessionId' if eval_number >= 8 else 'admSession'
     adm_session = medic_collection.find_one({'evalNumber': 5 if eval_number == 6 else eval_number, 'name': page})[ADM_SESSION_VAR_NAME]
     
     adms = []
@@ -93,7 +93,7 @@ def find_adm_from_medic(eval_number, medic_collection, adm_collection, page, pag
         adms = adm_collection.find({
             'evaluation.evalNumber': str(eval_number),
             'evaluation.scenario_id': page_scenario,
-            'evaluation.adm_name': survey['results'][page]['admName'],
+            'adm_name': survey['results'][page]['admName'],
             'evaluation.alignment_target_id': survey['results'][page]['admTarget']
         })
 


### PR DESCRIPTION
[Repopulation ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?jql=assignee%20%3D%2060ba425da547eb00686ee0ce&selectedIssue=ITM-1085)
[Redo script tweak ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?jql=assignee%20%3D%2060ba425da547eb00686ee0ce&selectedIssue=ITM-1083)

Set up your `.env` file to point to your local ADEPT server. For the repopulation script to work properly, you will need to have all of the July and June YAML files accounted for. 

`python deployment_script.py`

This will take a few minutes. After running, the session IDs for human results, as well as the ADM runs, should be stored on your local ADEPT server. Now we can test the changes to the redo script while also generating some comparison scores. 

I realized that there are certain instances where we will need to be able to pass an argument when running `redo.py`. For example, script `083` generated the June comparison scores for delegators against the observed ADMS. That script has an `EVAL_NUMBER` parameter (with default value of 8), but will work the same for eval number 9. In this case, we can use our Jenkins job for the redo script, but it needs to be capable of passing a new `EVAL_NUMBER`.

Changes: 
- Minor tweak to `083` in a few spots that had eval 8 specific logic hard-coded
- redo.py can take additional arguments from the command line
- redo.py determines what type the argument should be treated as (int, float, bool, string)

A quick way to test this would be to run `python redo.py 083 9`. The redo script should identify that we need to run script 083, and then pass 9 (as an int) as the `EVAL_NUMBER`. You should then be able to check `humanToADMComparison` with  `{ evalNumber: 9 }` and see documents that were not previously there. Let me know if you need the latest db backup to test this.

Note: Jenkins job update accompanies this, but is not part of reviewing this pr. 