### PR TITLE
ITM 1101: Remove Excess Date Strings from ADM Names

### DIFF
--- a/scripts/_0_8_9_ph2_repop_cleanup.py
+++ b/scripts/_0_8_9_ph2_repop_cleanup.py
@@ -10,3 +10,4 @@ def main(mongo_db):
         
     # repopulate ta1 server
     ph2_repop(mongo_db)
+    

--- a/scripts/_0_8_9_ph2_repop_cleanup.py
+++ b/scripts/_0_8_9_ph2_repop_cleanup.py
@@ -1,5 +1,4 @@
 from ph2_repop import main as ph2_repop
-from datetime import datetime
 
 def main(mongo_db):
     adm_runs = mongo_db['admTargetRuns']
@@ -8,22 +7,6 @@ def main(mongo_db):
         {'evalNumber': 8, 'adm_name': {'$regex': '__'}},
         [{'$set': {'adm_name': {'$arrayElemAt': [{'$split': ['$adm_name', '__']}, 0]}}}]
     )
-    
-    documents = adm_runs.find({'evalNumber': 8})
-    
-    for doc in documents:
-        current_name = doc.get('adm_name', '')
-        start_time_str = doc.get('evaluation', {}).get('start_time', '')
         
-        if start_time_str and start_time_str.strip() and start_time_str != '-':
-            dt = datetime.strptime(start_time_str.split('.')[0], "%Y-%m-%d %H:%M:%S")
-            new_name = f"{current_name}_{dt.month}_{dt.day}"
-            
-            adm_runs.update_one(
-                {'_id': doc['_id']},
-                {'$set': {'adm_name': new_name}}
-            )
-    
-    
     # repopulate ta1 server
     ph2_repop(mongo_db)

--- a/scripts/_0_8_9_ph2_repop_cleanup.py
+++ b/scripts/_0_8_9_ph2_repop_cleanup.py
@@ -10,4 +10,3 @@ def main(mongo_db):
         
     # repopulate ta1 server
     ph2_repop(mongo_db)
-    

--- a/scripts/_0_8_9_ph2_repop_cleanup.py
+++ b/scripts/_0_8_9_ph2_repop_cleanup.py
@@ -1,12 +1,5 @@
 from ph2_repop import main as ph2_repop
 
-def main(mongo_db):
-    adm_runs = mongo_db['admTargetRuns']
-
-    adm_runs.update_many(
-        {'evalNumber': 8, 'adm_name': {'$regex': '__'}},
-        [{'$set': {'adm_name': {'$arrayElemAt': [{'$split': ['$adm_name', '__']}, 0]}}}]
-    )
-        
+def main(mongo_db):        
     # repopulate ta1 server
     ph2_repop(mongo_db)

--- a/scripts/_0_9_2_standardize_adm_names.py
+++ b/scripts/_0_9_2_standardize_adm_names.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+def main(mongo_db):
+    adm_runs = mongo_db['admTargetRuns']
+
+    documents = adm_runs.find({'evalNumber': {'$gte': 8}})
+
+    for doc in documents:
+        current_name = doc.get('adm_name', '')
+        start_time_str = doc.get('evaluation', {}).get('start_time', '')
+
+        if start_time_str and start_time_str.strip() and start_time_str != '-':
+            dt = datetime.strptime(start_time_str.split('.')[0], "%Y-%m-%d %H:%M:%S")
+            expected_token = f"_{dt.month}_{dt.day}"
+
+            base_name = current_name
+            token_len = len(expected_token)
+            while token_len > 0 and base_name.endswith(expected_token):
+                base_name = base_name[:-token_len]
+
+            new_name = f"{base_name}{expected_token}"
+
+            if new_name != current_name:
+                adm_runs.update_one(
+                    {'_id': doc['_id']},
+                    {'$set': {'adm_name': new_name}}
+                )

--- a/scripts/_0_9_2_standardize_adm_names.py
+++ b/scripts/_0_9_2_standardize_adm_names.py
@@ -3,6 +3,11 @@ from datetime import datetime
 def main(mongo_db):
     adm_runs = mongo_db['admTargetRuns']
 
+    adm_runs.update_many(
+        {'evalNumber': {'$gte': 8}, 'adm_name': {'$regex': '__'}},
+        [{'$set': {'adm_name': {'$arrayElemAt': [{'$split': ['$adm_name', '__']}, 0]}}}]
+    )
+
     documents = adm_runs.find({'evalNumber': {'$gte': 8}})
 
     for doc in documents:


### PR DESCRIPTION
**Original Ticket:** [Here](https://nextcentury.atlassian.net/browse/ITM-1101?atlOrigin=eyJpIjoiNzc0ZTZjNmNhMTZiNGJjNjg0OGM3OWY3ZWY0ZDM1MDkiLCJwIjoiaiJ9)

## Description: 
This PR addresses a concern with the formatting of ADM names discovered by @nextcen-dgemoets. Because we had to run the deployment script multiple times, the logic appending dates to the end of ADM names in the `_0_8_9_ph2_repop_cleanup.py` script was being executed over and over again. The script logic assumed that the date string was non-existent and added the date string whenever the start time information was available. This resulted in ADM names with the date modifier being appended multiple times (e.g.: `ALIGN-ADM-OutlinesBaseline-Mistral-7B-Instruct-v0.3_6_24_6_24_6_24_6_24_6_24`). Furthermore, dates were only being appended to the end of ADM names for eval 8 runs. In this PR, the problematic date appending logic in `_0_8_9_ph2_repop_cleanup.py` is removed. This logic is refactored in a new script, `_0_9_2_standardize_adm_names.py`. In this script, for any ADM run where the start time information is present, all repetitions of the date currently existing are first trimmed. Next, the date is added only once to the end of the ADM name. Database updates occur per document. Additionally, this logic now applies to all eval numbers greater than or equal to 8, making this script futureproof.

## How To Test: 
1. Run the Ingest deployment script using `python deployment_script.py.` Ensure that after the script runs, your database version was successfully updated to `0.9.2.`
2. Open Mongo compass and click on the `admTargetRuns` collection. Filter using the below command and look at the resultant documents. These are eval 8 and eval 9 documents with valid start times. Choose a few of the resultant documents and ensure that the `adm_name` parameter ends with exactly one date string that matches the start date parameter (`evaluation.start_time`).

```
{
  "evalNumber": { "$in": [8, 9] },
  "evaluation.start_time": { "$ne": "-" }
}
```
3. Now, replace your filter query with the one below. These are eval 8 and eval 9 documents where start time information is not available. For these documents, verify that the `adm_name` parameter does not end with anything appearing to be a date.

```
{
  "evalNumber": { "$in": [8, 9] },
  "evaluation.start_time": "-"
}
```
4. To verify that rerunning the script does not cause the same date string to be appended to the end of the `adm_name` parameter, run the command `python redo.py 092`. After making sure it runs successfully, refresh Mongo compass. None of the document ADM names should have changed since the time you ran the deployment script (there should not be duplicate trailing date substrings tacked on to any ADM name).
5. Navigate to `http://localhost:3000/results`. Select "Phase 2 June 2025 Collaboration" for `Evaluation`. Select any `Scenario`. For any one that you select, all options in the `Performer/ADM Name` dropdown should terminate with exactly one date substring. 
6. For good measure, click on any of these options and then select an `Alignment Target`. The `ADM` block in the top right corner of the new header should also show the ADM name with one date substring.