### PR TITLE
Post scenario measures in text assessment

### DIFF
--- a/scripts/_0_9_6_add_text_demographics.py
+++ b/scripts/_0_9_6_add_text_demographics.py
@@ -1,0 +1,38 @@
+import os, json
+
+excluded= [
+    'What was the biggest influence on your delegation decision between different medics?',
+    'As I was reading through the scenarios and Medic decisions, I actively thought about how I would handle the same situation',
+    'I had enough information in this presentation to make the ratings for the questions asked on the previous pages about the DMs'
+]
+
+def main(mongo_db):
+    text_configs = mongo_db['textBasedConfig']
+    
+    json_file_path = 'delegation_survey/survey-configs/postScenarioPhase2.json'
+    with open(json_file_path, 'r') as file:
+        measures = json.load(file)
+    
+    elements = []
+    page = measures['pages'][0]
+    for element in page['elements']:
+        if element['name'] not in excluded:
+            elements.append(element)
+
+    updated_page = {
+        'name': "Post-Scenario Measures",
+        "elements": elements
+    }
+
+    doc = {
+        'name': 'Post-Scenario Measures Phase 2',
+        'pages': updated_page,
+        'showQuestionNumbers': False,
+        'showPrevButton': False,
+        'title': 'Post-Scenario Measures Phase 2',
+        'logoPosition': 'right',
+        'completedHtml': '<h3>Thank you for completing the scenario</h3>',
+        'widthMode': 'responsive',
+    }
+
+    text_configs.insert_one(doc)


### PR DESCRIPTION
This script adds a config containing a modified demographics section from the delegation survey to be used following the text assessment. 

`python deployment_script.py`

You should see the config added in the `textBasedConfig` collection. 

[Dashboard pr](https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/350)