### PR TITLE
Update participant mistakenly marked as 'Test'

### DIFF
--- a/scripts/_0_9_7_fix_test_log.py
+++ b/scripts/_0_9_7_fix_test_log.py
@@ -1,0 +1,7 @@
+def main(mongo_db, pid=202507147):
+    participant_log = mongo_db['participantLog']
+
+    participant_log.find_one_and_update(
+        {'ParticipantID': pid},
+        {'$set': {'Type': 'emailParticipant'}}
+    )


### PR DESCRIPTION
[Ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?jql=assignee%20%3D%2060ba425da547eb00686ee0ce)

`python deployment_script.py`

This updates participant `202507147` to be included in our data sets. This participant was somehow marked as type `Test` instead of `emailParticipant`. I set up this script so it can be run again with the Jenkins redo job if this happens in the future (taking the PID that needs to be updated as an argument)