### PR TITLE
run fake adm, gen comp scores

### DIFF
--- a/delegation_survey/september_handmade_adms.py
+++ b/delegation_survey/september_handmade_adms.py
@@ -87,7 +87,9 @@ def create_adm(target, probe_set, attr, probe_set_index, template, medic_collect
         row_data = {
             'choice': scene['action_mapping'][choice]['unstructured'],
             'probe_unstructured': scene['state']['unstructured'],
-            'options': action_options
+            'options': action_options,
+            'probe_id': scene['action_mapping'][choice]['probe_id'],
+            'choice_id': scene['action_mapping'][choice]['choice']
         }
 
         doc['elements'][0]['rows'].append(row_data)

--- a/scripts/_0_8_3_June_Collab_Comparison_Generation.py
+++ b/scripts/_0_8_3_June_Collab_Comparison_Generation.py
@@ -40,9 +40,12 @@ def main(mongoDB, EVAL_NUMBER=8):
         for page in survey['results']:
             if 'Medic' in page and ' vs ' not in page:
                 page_scenario = survey['results'][page]['scenarioIndex']
-                adm = db_utils.find_adm_from_medic(EVAL_NUMBER, medic_collection, adm_collection, page, page_scenario, survey)
-                if adm is None:
+                if 'combined' in page_scenario or 'PS-AF' in page_scenario:
                     continue
+                if EVAL_NUMBER != 10:
+                    adm = db_utils.find_adm_from_medic(EVAL_NUMBER, medic_collection, adm_collection, page, page_scenario, survey)
+                    if adm is None:
+                        continue
 
                 adm_session = medic_collection.find_one({'evalNumber': EVAL_NUMBER, 'name': page})['admSessionId']
 
@@ -52,7 +55,7 @@ def main(mongoDB, EVAL_NUMBER=8):
                 if res is not None and 'score' in res:
                     document = {
                         'pid': pid,
-                        'adm_type': survey['results'][page]['admAlignment'],
+                        'adm_type': survey.get('results', {}).get(page, {}).get('admAlignment'),
                         'score': res['score'],
                         'text_scenario': scenario_id,
                         'text_session_id': session_id.replace('"', "").strip(),

--- a/scripts/_0_9_8_run_handmade_adms.py
+++ b/scripts/_0_9_8_run_handmade_adms.py
@@ -1,0 +1,55 @@
+"""
+The September 2025 Collaboration (Idaho) used hand made 'ADM' runs for the delegation survey
+This script will take those fake ADMs and run them through the ADEPT server so we can use them for scoring
+"""
+
+import requests
+from delegation_survey.september_handmade_adms import main as add_probe_ids
+import utils.db_utils as db_utils
+from decouple import config
+
+ADEPT_URL = config("ADEPT_URL")
+
+
+def main(mongo_db):
+    # will edit the admMedics collection for eval 10
+    # so that we have the corresponding probe ids for each choice
+    add_probe_ids(mongo_db)
+
+    medics = mongo_db["admMedics"]
+    sept_medics = medics.find({"evalNumber": 10})
+
+    for medic in sept_medics:
+        if "combined" in medic["scenarioIndex"] or "PS-AF" in medic["scenarioIndex"]:
+            # we can't score these ones yet
+            continue
+        sid = (
+            requests.post(f"{ADEPT_URL}api/v1/new_session")
+            .text.replace('"', "")
+            .strip()
+        )
+        scenario = medic["scenarioIndex"]
+        responses = medic["elements"][0]["rows"]
+        probes = []
+        for response in responses:
+            probes.append(
+                {
+                    "probe": {
+                        "choice": response["choice_id"],
+                        "probe_id": response["probe_id"],
+                    }
+                }
+            )
+        db_utils.send_probes(f"{ADEPT_URL}api/v1/response", probes, sid, scenario)
+        kdmas = requests.get(
+            f"{ADEPT_URL}api/v1/computed_kdma_profile?session_id={sid}"
+        ).json()
+        medics.update_one(
+            {"_id": medic["_id"]},
+            {
+                "$set": {
+                    "kdmas": kdmas,
+                    "admSessionId": sid,
+                }
+            },
+        )


### PR DESCRIPTION
Does not need review yet. Handing off this script to Kaitlyn to assist with RQ1 table. Will need future commits.

`python deployment_script.py`

Then to gen the comparison scores `python redo.py 083 10`