### PR TITLE
ITM-1137: Fix evaluation num/name for Phase 2 4K experiment ADM runs

### DIFF
--- a/scripts/_0_9_9_fix_4k_adms.py
+++ b/scripts/_0_9_9_fix_4k_adms.py
@@ -1,0 +1,29 @@
+def main(mongo_db):
+    adm_target_runs= mongo_db['admTargetRuns']
+ 
+    query = {
+        "evalNumber": 9,
+        "adm_name": "ALIGN-ADM-OutlinesBaseline-Mistral-7B-Instruct-v0.3__3d1ccf2f-4ff1-4229-b346-ce1d28680c58"
+    }
+
+    update = {
+        "$set": {
+            "evalNumber": 11,
+            "evaluation.evalNumber": 11,
+            "evalName": "Phase 2 4D Experiment",
+            "evaluation.evalName": "Phase 2 4D Experiment",
+            "adm_name": "ALIGN-ADM-OutlinesBaseline-Mistral-7B-Instruct-v0.3",
+            "evaluation.adm_name": "ALIGN-ADM-OutlinesBaseline-Mistral-7B-Instruct-v0.3"
+        }
+    }
+
+    print("Updating baseline ADM entries.")
+    result = adm_target_runs.update_many(query, update)
+    print(f'Updated {result.modified_count} ADM entries.')
+
+    query['adm_name'] = "ALIGN-ADM-Ph2-ComparativeRegression-BertRelevance-Mistral-7B-Instruct-v0.3__f630203b-f376-4cfa-8c74-8fa91a66e34b"
+    update['$set']['adm_name'] = "ALIGN-ADM-Ph2-ComparativeRegression-BertRelevance-Mistral-7B-Instruct-v0.3"
+    update['$set']['evaluation.adm_name'] = "ALIGN-ADM-Ph2-ComparativeRegression-BertRelevance-Mistral-7B-Instruct-v0.3"
+    print("Updating aligned ADM entries.")
+    result = adm_target_runs.update_many(query, update)
+    print(f'Updated {result.modified_count} ADM entries.')


### PR DESCRIPTION
**NOTE:**  For me, this script is taking hours to run with the full 30 subsets.  I don't know how much of that is VPN or just lots of compare_sessions requests.  But please LMK how long it takes, and if you're seeing any other problem that would lead to such slow performance.

We accidentally left the eval num set to 9 and the eval name set to `Phase 2 July 2025 Collaboration` before the ADMs ran.
This script goes back and fixes this in the DB, changing the eval num to 11 and the name to "Phase 2 4D Experiment"
It also cleans up the ADM names to remove the UUID.

You can run the deployment script-- you should see 248 baseline and 248 aligned entries updated.
- `python deployment_script.py`

Check your DB to see that there are now Eval 11 entries in the adm collection.

Or, what you could do (optionally) is first run the script via the redo script (`python redo.py 099`), then run the deployment script and see that zero entries were updated.

Note that the number here is 99, so sequentially, it should be run after the dev-to-main and its corresponding deployment.