### PR TITLE
Itm 1321: Generate Comparison Scores for April RQ1

### DIFF
--- a/scripts/_0_8_3_June_Collab_Comparison_Generation.py
+++ b/scripts/_0_8_3_June_Collab_Comparison_Generation.py
@@ -59,7 +59,7 @@ def main(mongoDB, EVAL_NUMBER=8):
                 elif scenario_attribute is None or scenario_attribute not in page_scenario:
                     continue
 
-                if EVAL_NUMBER != 10:
+                if EVAL_NUMBER != 10 and EVAL_NUMBER != 16:
                     adm = db_utils.find_adm_from_medic(EVAL_NUMBER, medic_collection, adm_collection, page, page_scenario, survey)
                     if adm is None:
                         continue
@@ -88,7 +88,7 @@ def main(mongoDB, EVAL_NUMBER=8):
                         else:
                             print(f'Error getting comparison for scenarios {scenario_id} and {adm_scenario_id} with text session {session_id} and adm session {adm_session}', res)
                 else:
-                    adm_session = medic_collection.find_one({'evalNumber': EVAL_NUMBER, 'name': page})['admSessionId']
+                    adm_session = medic['admSessionId']
 
                     res = requests.get(f'{ADEPT_URL}api/v1/alignment/compare_sessions?session_id_1={session_id}&session_id_2={adm_session}').json()
                     # send document to mongo

--- a/scripts/_1_3_5_rq1_april.py
+++ b/scripts/_1_3_5_rq1_april.py
@@ -12,6 +12,7 @@ def main(mongo_db):
 
 def run_obs(mongo_db):
     medics = mongo_db['admMedics']
+    adm_collec = mongo_db['admTargetRuns']
     observed_oracles = list(medics.find({'evalNumber': 16}))
 
     for oracle in observed_oracles:
@@ -44,6 +45,18 @@ def run_obs(mongo_db):
                     'kdmas': kdmas,
                 }
             }
+        )
+
+        adm_target_doc = {
+            **oracle,
+            'admSessionId': sid,
+            'kdmas': kdmas,
+        }
+
+        adm_collec.update_one(
+            {'_id': oracle['_id']},
+            {'$set': adm_target_doc},
+            upsert=True
         )
 
         print(f"Processed {oracle['name']} - {scenario_id} -> session {sid}")

--- a/scripts/_1_3_5_rq1_april.py
+++ b/scripts/_1_3_5_rq1_april.py
@@ -207,7 +207,8 @@ def gen_comp(mongo_db):
                 }
 
                 if medic['admName'] == 'Oracle':
-                    document['subpop'] = participant_subpop
+                    document['oracle_subpop'] = page_data.get('subpop')
+                    document['participant_subpop'] = participant_subpop
 
                 send_document_to_mongo(comparison_collection, document)
             else:

--- a/scripts/_1_3_5_rq1_april.py
+++ b/scripts/_1_3_5_rq1_april.py
@@ -8,7 +8,7 @@ ADEPT_URL = config('ADEPT_URL')
 
 def main(mongo_db):
     run_obs(mongo_db)
-    gen_comp(mongo_db, EVAL_NUMBER=16)
+    gen_comp(mongo_db)
 
 def run_obs(mongo_db):
     medics = mongo_db['admMedics']
@@ -132,7 +132,6 @@ def gen_comp(mongo_db):
             if res is not None and 'score' in res:
                 document = {
                     'pid': pid,
-                    'adm_type': page_data.get('admAlignment'),
                     'score': res['score'],
                     'text_scenario': scenario_id,
                     'text_session_id': session_id.replace('"', '').strip(),

--- a/scripts/_1_3_5_rq1_april.py
+++ b/scripts/_1_3_5_rq1_april.py
@@ -4,7 +4,6 @@ Runs oracle adms through TA1 server so session id's are available for rq1 compar
 import requests
 from decouple import config
 import utils.db_utils as db_utils
-from scripts._0_8_3_June_Collab_Comparison_Generation import main as gen_comp
 ADEPT_URL = config('ADEPT_URL')
 
 def main(mongo_db):
@@ -48,3 +47,78 @@ def run_obs_oracles(mongo_db):
         )
 
         print(f"Processed {oracle['name']} - {scenario_id} -> session {sid}")
+
+def gen_comp(mongo_db):
+    EVAL_NUMBER = 16
+    text_scenario_collection = mongoDB['userScenarioResults']
+    delegation_collection = mongoDB['surveyResults']
+    comparison_collection = mongoDB['humanToADMComparison']
+
+    comparison_collection.delete_many({"evalNumber": EVAL_NUMBER})
+    medic_collection = mongoDB['admMedics']
+
+    data_to_use = list(text_scenario_collection.find(
+        {"evalNumber": EVAL_NUMBER}
+    ))
+
+    total_text_scenarios = text_scenario_collection.count_documents(
+        {"evalNumber": EVAL_NUMBER}
+    )
+
+    for entry in data_to_use:
+        print(f"Currently processing {current_text_scenario} of {total_text_scenarios} total text scenarios Evaluation {EVAL_NUMBER}.")
+        current_text_scenario += 1
+
+        scenario_id = entry.get('scenario_id')
+        session_id = entry.get('combinedSessionId')
+        pid = entry.get('participantID')
+        survey = list(delegation_collection.find({"results.pid": pid}))
+        if len(survey) == 0:
+            print(f"No survey found for {pid}")
+            continue
+        survey = survey[-1] # get last survey entry for this pid
+        # get human to adm comparisons from delegation survey adms
+        for page in survey['results']:
+            if 'Medic' in page and ' vs ' not in page:
+                page_scenario = survey['results'][page]['scenarioIndex']
+                scenario_attribute = next((x for x in ['MF', 'SS', 'PS', 'AF'] if x in scenario_id), None)
+
+                medic = medic_collection.find_one({'evalNumber': EVAL_NUMBER, 'name': page})
+                adm_session = medic['admSessionId']
+
+                res = requests.get(f'{ADEPT_URL}api/v1/alignment/compare_sessions?session_id_1={session_id}&session_id_2={adm_session}').json()
+                # send document to mongo
+                if res is not None and 'score' in res:
+                    document = {
+                        'pid': pid,
+                        'adm_type': survey.get('results', {}).get(page, {}).get('admAlignment'),
+                        'score': res['score'],
+                        'text_scenario': scenario_id,
+                        'text_session_id': session_id.replace('"', "").strip(),
+                        'adm_scenario': page_scenario,
+                        'adm_session_id': adm_session,
+                        'adm_alignment_target': survey['results'][page]['admTarget'],
+                        'evalNumber': EVAL_NUMBER
+                    }
+                    send_document_to_mongo(comparison_collection, document)
+                else:
+                    print(f'Error getting comparison for scenarios {scenario_id} and {page_scenario} with text session {session_id} and adm session {adm_session}', res)
+
+
+    print("Human to ADM comparison values added to database.")
+
+
+def send_document_to_mongo(comparison_collection, document):
+    # do not send duplicate documents, make sure if one already exists, we just replace it
+    found_docs = comparison_collection.find({'pid': document['pid'], 'adm_type': document['adm_type'], 'text_scenario': document['text_scenario'], 'adm_scenario': document['adm_scenario'], 'evalNumber': document['evalNumber'],
+                                            'text_session_id': document['text_session_id'], 'adm_session_id': document['adm_session_id'], 'adm_alignment_target': document['adm_alignment_target']})
+    doc_found = False
+    obj_id = ''
+    for doc in found_docs:
+        doc_found = True
+        obj_id = doc['_id']
+        break
+    if doc_found:
+        comparison_collection.update_one({'_id': obj_id}, {'$set': document})
+    else:
+        comparison_collection.insert_one(document)

--- a/scripts/_1_3_5_rq1_april.py
+++ b/scripts/_1_3_5_rq1_april.py
@@ -50,60 +50,100 @@ def run_obs_oracles(mongo_db):
 
 def gen_comp(mongo_db):
     EVAL_NUMBER = 16
-    text_scenario_collection = mongoDB['userScenarioResults']
-    delegation_collection = mongoDB['surveyResults']
-    comparison_collection = mongoDB['humanToADMComparison']
+    text_scenario_collection = mongo_db['userScenarioResults']
+    delegation_collection = mongo_db['surveyResults']
+    comparison_collection = mongo_db['humanToADMComparison']
 
     comparison_collection.delete_many({"evalNumber": EVAL_NUMBER})
-    medic_collection = mongoDB['admMedics']
+    medic_collection = mongo_db['admMedics']
 
     data_to_use = list(text_scenario_collection.find(
         {"evalNumber": EVAL_NUMBER}
     ))
 
-    total_text_scenarios = text_scenario_collection.count_documents(
-        {"evalNumber": EVAL_NUMBER}
-    )
+    total_text_scenarios = len(data_to_use)
+    current_text_scenario = 0
 
     for entry in data_to_use:
-        print(f"Currently processing {current_text_scenario} of {total_text_scenarios} total text scenarios Evaluation {EVAL_NUMBER}.")
         current_text_scenario += 1
+        print(f"Currently processing {current_text_scenario} of {total_text_scenarios} total text scenarios Evaluation {EVAL_NUMBER}.")
 
         scenario_id = entry.get('scenario_id')
-        session_id = entry.get('combinedSessionId')
         pid = entry.get('participantID')
-        survey = list(delegation_collection.find({"results.pid": pid}))
+
+        survey = list(delegation_collection.find({"results.pid": pid, "results.evalNumber": EVAL_NUMBER}))
         if len(survey) == 0:
             print(f"No survey found for {pid}")
             continue
-        survey = survey[-1] # get last survey entry for this pid
-        # get human to adm comparisons from delegation survey adms
+        survey = survey[-1]
+
+        # PS document has all three session ids I need, so just grab that
+        ps2_doc = text_scenario_collection.find_one({
+            'participantID': pid,
+            'evalNumber': EVAL_NUMBER,
+            'scenario_id': {'$regex': 'PS'}
+        })
+        if not ps2_doc:
+            print(f"No PS document found for {pid}")
+            continue
+
         for page in survey['results']:
-            if 'Medic' in page and ' vs ' not in page:
-                page_scenario = survey['results'][page]['scenarioIndex']
-                scenario_attribute = next((x for x in ['MF', 'SS', 'PS', 'AF'] if x in scenario_id), None)
+            if 'Medic' not in page or ' vs ' in page:
+                continue
 
-                medic = medic_collection.find_one({'evalNumber': EVAL_NUMBER, 'name': page})
-                adm_session = medic['admSessionId']
+            page_data = survey['results'][page]
+            page_scenario = page_data.get('scenarioIndex')
+            if not page_scenario:
+                continue
 
-                res = requests.get(f'{ADEPT_URL}api/v1/alignment/compare_sessions?session_id_1={session_id}&session_id_2={adm_session}').json()
-                # send document to mongo
-                if res is not None and 'score' in res:
-                    document = {
-                        'pid': pid,
-                        'adm_type': survey.get('results', {}).get(page, {}).get('admAlignment'),
-                        'score': res['score'],
-                        'text_scenario': scenario_id,
-                        'text_session_id': session_id.replace('"', "").strip(),
-                        'adm_scenario': page_scenario,
-                        'adm_session_id': adm_session,
-                        'adm_alignment_target': survey['results'][page]['admTarget'],
-                        'evalNumber': EVAL_NUMBER
-                    }
-                    send_document_to_mongo(comparison_collection, document)
-                else:
-                    print(f'Error getting comparison for scenarios {scenario_id} and {page_scenario} with text session {session_id} and adm session {adm_session}', res)
+            # figure out what session id to use 
+            if 'MF-PS' in page_scenario:
+                session_id = ps2_doc.get('MF-PS_sessionId')
+            elif 'AF-PS' in page_scenario:
+                session_id = ps2_doc.get('AF-PS_sessionId')
+            elif 'MF-observe' in page_scenario or 'AF-observe' in page_scenario:
+                session_id = ps2_doc.get('combinedSessionId')
+            else:
+                #shouldnt happen
+                print(f"Couldnt match page_scenario of {page_scenario}")
+                continue
 
+            if not session_id:
+                print(f"No session ID found for {pid} page {page} scenario {page_scenario}")
+                continue
+
+            # Match text scenario attribute to medic scenario attribute
+            scenario_attribute = next((x for x in ['MF', 'SS', 'PS', 'AF'] if x in scenario_id), None)
+            if scenario_attribute is None or scenario_attribute not in page_scenario:
+                continue
+
+            medic = medic_collection.find_one({'evalNumber': EVAL_NUMBER, 'name': page})
+            if not medic:
+                print(f"No medic found for {page}")
+                continue
+
+            adm_session = medic.get('admSessionId')
+            if not adm_session:
+                print(f"No admSessionId for medic {page}")
+                continue
+
+            res = requests.get(f'{ADEPT_URL}api/v1/alignment/compare_sessions?session_id_1={session_id}&session_id_2={adm_session}').json()
+
+            if res is not None and 'score' in res:
+                document = {
+                    'pid': pid,
+                    'adm_type': page_data.get('admAlignment'),
+                    'score': res['score'],
+                    'text_scenario': scenario_id,
+                    'text_session_id': session_id.replace('"', '').strip(),
+                    'adm_scenario': page_scenario,
+                    'adm_session_id': adm_session,
+                    'adm_alignment_target': page_data.get('admTarget'),
+                    'evalNumber': EVAL_NUMBER
+                }
+                send_document_to_mongo(comparison_collection, document)
+            else:
+                print(f'Error getting comparison for {scenario_id} and {page_scenario} with text session {session_id} and adm session {adm_session}', res)
 
     print("Human to ADM comparison values added to database.")
 

--- a/scripts/_1_3_5_rq1_april.py
+++ b/scripts/_1_3_5_rq1_april.py
@@ -4,15 +4,26 @@ Runs oracle adms through TA1 server so session id's are available for rq1 compar
 import requests
 from decouple import config
 import utils.db_utils as db_utils
+from bson import ObjectId
 ADEPT_URL = config('ADEPT_URL')
 
 def main(mongo_db):
+    survey_collection = mongo_db['surveyResults']
+    # fix participant that reported wrong pid
+    id = '69d94c5f7d9621bcf9c5f7ef'
+    survey_collection.update_one(
+        {'_id': ObjectId(id)},
+        {'$set': {
+            'results.pid': '202604117',
+            'results.Participant ID Page.questions.Participant ID.response': '202604117',
+        }}
+    )
+
     run_obs(mongo_db)
     gen_comp(mongo_db)
 
 def run_obs(mongo_db):
     medics = mongo_db['admMedics']
-    adm_collec = mongo_db['admTargetRuns']
     observed_oracles = list(medics.find({'evalNumber': 16}))
 
     for oracle in observed_oracles:
@@ -37,26 +48,28 @@ def run_obs(mongo_db):
             f"{ADEPT_URL}api/v1/computed_kdma_profile?session_id={sid}"
         ).json()
 
+        alignment_params = {
+            'session_id': sid,
+            'target_id': oracle.get('target'),
+        }
+        if oracle.get('subpop'):
+            alignment_params['enable_subpop'] = oracle['subpop']
+
+        alignment_score = requests.get(
+            f"{ADEPT_URL}api/v1/alignment/session",
+            params=alignment_params
+        ).json()
+
+
         medics.update_one(
             {'_id': oracle['_id']},
             {
                 '$set': {
-                    'admSessionId': sid,
-                    'kdmas': kdmas,
+                'admSessionId': sid,
+                'kdmas': kdmas,
+                'alignmentScore': alignment_score.get('score'),
                 }
             }
-        )
-
-        adm_target_doc = {
-            **oracle,
-            'admSessionId': sid,
-            'kdmas': kdmas,
-        }
-
-        adm_collec.update_one(
-            {'_id': oracle['_id']},
-            {'$set': adm_target_doc},
-            upsert=True
         )
 
         print(f"Processed {oracle['name']} - {scenario_id} -> session {sid}")

--- a/scripts/_1_3_5_rq1_april.py
+++ b/scripts/_1_3_5_rq1_april.py
@@ -1,0 +1,50 @@
+'''
+Runs oracle adms through TA1 server so session id's are available for rq1 comparisons
+'''
+import requests
+from decouple import config
+import utils.db_utils as db_utils
+from scripts._0_8_3_June_Collab_Comparison_Generation import main as gen_comp
+ADEPT_URL = config('ADEPT_URL')
+
+def main(mongo_db):
+    run_obs_oracles(mongo_db)
+    gen_comp(mongo_db, EVAL_NUMBER=16)
+
+def run_obs_oracles(mongo_db):
+    medics = mongo_db['admMedics']
+    observed_oracles = list(medics.find({'evalNumber': 16, 'admName': 'Oracle'}))
+
+    for oracle in observed_oracles:
+        responses = oracle['elements'][0]['rows']
+        scenario_id = responses[0]['scenario_id']
+
+        sid = requests.post(f"{ADEPT_URL}api/v1/new_session").text.replace('"', '').strip()
+
+        probes = [
+            {
+                'probe': {
+                    'choice': response['choice_id'],
+                    'probe_id': response['probe_id'],
+                }
+            }
+            for response in responses
+        ]
+
+        db_utils.send_probes(f"{ADEPT_URL}api/v1/response", probes, sid, scenario_id)
+
+        kdmas = requests.get(
+            f"{ADEPT_URL}api/v1/computed_kdma_profile?session_id={sid}"
+        ).json()
+
+        medics.update_one(
+            {'_id': oracle['_id']},
+            {
+                '$set': {
+                    'admSessionId': sid,
+                    'kdmas': kdmas,
+                }
+            }
+        )
+
+        print(f"Processed {oracle['name']} - {scenario_id} -> session {sid}")

--- a/scripts/_1_3_5_rq1_april.py
+++ b/scripts/_1_3_5_rq1_april.py
@@ -83,9 +83,22 @@ def gen_comp(mongo_db):
             'evalNumber': EVAL_NUMBER,
             'scenario_id': {'$regex': 'PS'}
         })
+
         if not ps2_doc:
             print(f"No PS document found for {pid}")
             continue
+
+        subpop_doc = text_scenario_collection.find_one({
+            'participantID': pid,
+            'evalNumber': 16,
+            'scenario_id': {'$regex': 'subpopulation'}
+        })
+
+        if not subpop_doc:
+            print(f"No subpop document found for {pid}")
+            continue
+
+        participant_subpop = subpop_doc.get('subPopResult')
 
         for page in survey['results']:
             if 'Medic' not in page or ' vs ' in page:
@@ -127,7 +140,33 @@ def gen_comp(mongo_db):
                 print(f"No admSessionId for medic {page}")
                 continue
 
-            res = requests.get(f'{ADEPT_URL}api/v1/alignment/compare_sessions?session_id_1={session_id}&session_id_2={adm_session}').json()
+            base_url = f'{ADEPT_URL}api/v1/alignment/compare_sessions'
+
+            query_params = {
+                'session_id_1': session_id,
+                'session_id_2': adm_session,
+            }
+
+            # Only add optional params if they exist
+            if medic['admName'] == 'Oracle':
+                if participant_subpop:
+                    query_params['enable_subpop'] = participant_subpop
+
+                query_params['kdma_filter'] = (
+                    'affiliation' if 'AF' in medic['scenarioIndex'] else 'merit'
+                )
+
+            response = requests.get(base_url, params=query_params)
+
+            if response.status_code != 200:
+                print(f"Request failed: {response.status_code} - {response.text}")
+                continue
+
+            try:
+                res = response.json()
+            except Exception:
+                print(f"Invalid JSON response: {response.text}")
+                continue
 
             if res is not None and 'score' in res:
                 document = {
@@ -138,8 +177,12 @@ def gen_comp(mongo_db):
                     'adm_scenario': page_scenario,
                     'adm_session_id': adm_session,
                     'adm_alignment_target': page_data.get('admTarget'),
-                    'evalNumber': EVAL_NUMBER
+                    'evalNumber': EVAL_NUMBER,
                 }
+
+                if medic['admName'] == 'Oracle':
+                    document['subpop'] = participant_subpop
+
                 send_document_to_mongo(comparison_collection, document)
             else:
                 print(f'Error getting comparison for {scenario_id} and {page_scenario} with text session {session_id} and adm session {adm_session}', res)
@@ -149,7 +192,7 @@ def gen_comp(mongo_db):
 
 def send_document_to_mongo(comparison_collection, document):
     # do not send duplicate documents, make sure if one already exists, we just replace it
-    found_docs = comparison_collection.find({'pid': document['pid'], 'adm_type': document['adm_type'], 'text_scenario': document['text_scenario'], 'adm_scenario': document['adm_scenario'], 'evalNumber': document['evalNumber'],
+    found_docs = comparison_collection.find({'pid': document['pid'], 'text_scenario': document['text_scenario'], 'adm_scenario': document['adm_scenario'], 'evalNumber': document['evalNumber'],
                                             'text_session_id': document['text_session_id'], 'adm_session_id': document['adm_session_id'], 'adm_alignment_target': document['adm_alignment_target']})
     doc_found = False
     obj_id = ''

--- a/scripts/_1_3_5_rq1_april.py
+++ b/scripts/_1_3_5_rq1_april.py
@@ -7,12 +7,12 @@ import utils.db_utils as db_utils
 ADEPT_URL = config('ADEPT_URL')
 
 def main(mongo_db):
-    run_obs_oracles(mongo_db)
+    run_obs(mongo_db)
     gen_comp(mongo_db, EVAL_NUMBER=16)
 
-def run_obs_oracles(mongo_db):
+def run_obs(mongo_db):
     medics = mongo_db['admMedics']
-    observed_oracles = list(medics.find({'evalNumber': 16, 'admName': 'Oracle'}))
+    observed_oracles = list(medics.find({'evalNumber': 16}))
 
     for oracle in observed_oracles:
         responses = oracle['elements'][0]['rows']


### PR DESCRIPTION
Runs the Oracle ADMs through the TA1 server. Also repopulated the MF-PS and AF-PS ADM runs so they are available for comparison scores. Generates comparison scores between participants and the observed ADMs. 

Fixes the issue of the participant who gave us the wrong PID. 

`python deployment_script.py` or `python redo.py 135`


[Dashboard pr](https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/459)


Note: The repopulation script is not compatible with this evaluation. I am working on an update, but in the meantime, you can point at production. 