### PR TITLE
Triage performance calculation update

### DIFF
--- a/feb2026_probe_matcher.py
+++ b/feb2026_probe_matcher.py
@@ -1439,9 +1439,24 @@ class ProbeMatcher:
         # score = hits / (tools_applied + misses) * 100
         # -------------------------
         def get_triage_performance():
+            """
+            June-style supplemental-aware triage performance.
+
+            Numerator:
+              - completed required injuries
+              - approved supplemental tools, but only once a patient has no
+                required injuries remaining
+
+            Denominator:
+              - all TOOL_APPLIED events except Pulse Oximeter
+              - plus remaining required injuries (misses)
+            """
             remaining = {p: set(inj_list) for p, inj_list in required_injuries.items()}
-            correct_completed = 0
+            supplemental = copy.deepcopy(SUPPLEMENTAL_PROCEDURES.get(env.lower(), {}))
+            supplemental_tracker = {}
+            correct_tools_applied = 0
             total_tools_applied = 0
+            just_completed = None
 
             for row in data:
                 ev = _get_cell(row, idx, "EventName")
@@ -1452,25 +1467,36 @@ class ProbeMatcher:
                     completed = _safe_bool_from_csv(
                         _get_cell(row, idx, "InjuryTreatmentComplete")
                     )
-                    if (
-                        completed
-                        and patient in remaining
-                        and injury in remaining[patient]
-                    ):
+                    if completed and patient in remaining and injury in remaining[patient]:
                         remaining[patient].remove(injury)
-                        correct_completed += 1
+                        correct_tools_applied += 1
+                        just_completed = patient
                         if len(remaining[patient]) == 0:
                             del remaining[patient]
 
                 if ev == "TOOL_APPLIED":
+                    patient = _clean_patient_name(_get_cell(row, idx, "PatientID", ""))
                     tool = str(_get_cell(row, idx, "ToolType", "") or "")
                     if "Pulse Oximeter" in tool:
                         continue
+
                     total_tools_applied += 1
+
+                    if tool in supplemental.get(patient, []):
+                        tracker = supplemental_tracker.setdefault(patient, {})
+                        already_used = tracker.get(tool, 0) > 0
+                        patient_has_required_remaining = patient in remaining and len(remaining[patient]) > 0
+
+                        if not already_used and not patient_has_required_remaining and patient != just_completed:
+                            correct_tools_applied += 1
+
+                        tracker[tool] = tracker.get(tool, 0) + 1
+
+                    just_completed = None
 
             misses = sum(len(s) for s in remaining.values())
             denom = max(1, total_tools_applied + misses)
-            return (correct_completed / denom) * 100.0
+            return (correct_tools_applied / denom) * 100.0
 
         results[f"{env} Triage Performance"] = get_triage_performance()
 


### PR DESCRIPTION
# PR: Update Triage Performance + Fix Alignment KDMA Fetching

## Summary

This PR includes the following updates:

- Updates **Triage Performance** calculation to account for **supplemental procedures** (aligned with June/April logic)
- Ensures **alignment KDMAs (MF/AF)** are properly fetched by restoring valid ADEPT session IDs when needed

---

## Why This Change

### 1. Triage Performance Bug
The February probe matcher previously:
- Only considered **required treatments**
- Ignored **supplemental procedures**, even though those metrics were computed

This resulted in **underreported performance values**.

This PR fixes that by:
- Incorporating supplemental procedures into the calculation
- Matching the logic used in June and April matchers

---

### 2. Alignment KDMA Issues (NaN values)

Observed on prod:
- `MF Alignment_Desert`
- `AF Alignment_Desert`
- `MF Alignment_Urban`
- `AF Alignment_Urban`

These values were returning **NaN**, which typically indicates:
- Missing or invalid ADEPT session IDs

Fix approach:
- Rerun probe matcher and/or
- Use `ph2_repop.py` to regenerate ADEPT sessions and repopulate probe responses

---

## How to Test

### 1. Setup ADEPT Locally

Run a local ADEPT server and ensure sessions are populated:

```bash
python ph2_repop.py
```

> This recreates ADEPT sessions and re-sends probe responses.

---

### 2. Capture Baseline Data

- Open the dashboard (local or prod)
- Download **RQ8 table data**
- Keep this for comparison

---

### 3. Run Updated Probe Matcher

```bash
python feb2026_probe_matcher.py -i ph2_feb2026_sim_files
```

> Do **not** pass `--no_kdmas` since alignment KDMAs need to be recomputed.

Recommended:
- Let several sim files process
- Note the PIDs of processed runs

---

### 4. Validate in MongoDB

Using Mongo Compass:

Check collection:
```
humanSimulator
```

Navigate to the `actionAnalysis` section of the document for each processed run.

Verify:

#### ✅ Triage Performance Updated
- `Desert Triage Performance` OR `Urban Triage Performance`
- Should be **higher than before** when supplemental procedures are present

#### ✅ Alignment KDMAs Fixed
- `MF Alignment_Desert` / `AF Alignment_Desert`
- `MF Alignment_Urban` / `AF Alignment_Urban`
- Should **NOT be NaN**

---

## Expected Results

- Triage Performance reflects **supplemental + required treatments**
- Alignment values are properly populated (no NaNs)
- No regressions in other extracted fields

---

## Notes

- `ph2_repop.py` is **safe to rerun**, but:
  - It creates **new ADEPT sessions**
  - It is not strictly idempotent
- This PR does **not** change probe matching logic, only:
  - Triage calculation
  - Alignment reliability