### PR TITLE
ITM-1343: Repop Target Eval 15

### DIFF
--- a/ph2_repop.py
+++ b/ph2_repop.py
@@ -16,8 +16,8 @@ ADEPT_URL = config("ADEPT_URL")
 
 
 def main(mongo_db):
-   text_scenarios = mongo_db["userScenarioResults"].find({"evalNumber": {"$gte": 15}})
-   adm_runs = mongo_db["admTargetRuns"].find({"evalNumber": {"$gte": 15}})
+   text_scenarios = mongo_db["userScenarioResults"].find({"evalNumber": 15})
+   adm_runs = mongo_db["admTargetRuns"].find({"evalNumber": 15})
 
    # group text scenarios by pid
    participant_groups = defaultdict(list)


### PR DESCRIPTION
## Summary

This update is a quick fix for the `ph2_repop.py` script to make it target only the eval 15 session ids. This is so that the `feb2026_probe_matcher.py` script can be reran successfully on prod.

## How to test

1. Checkout this branch, ensure your `.env` file is pointed at your local adept server, and run:
     - `py ph2_repop.py`
2. Let that script complete and run:
     - `py feb2026_probe_matcher.py -i ph2_feb2026_sim_files`
3. Let one or two session runs complete from the probe matcher, copy their PIDs, and use them to filter the `humanSimulator` collection in Mongo Compass. Ensure that the `MF/AF Alignment_Urban/Desert` were populated at the end of the `actionAnalysis` array and are not `NaN`.