### PR TITLE
New June 2026 YAML files. 

### DIFF
--- a/phase2/june2026/assess/june2026-adept-assess-AF.yaml
+++ b/phase2/june2026/assess/june2026-adept-assess-AF.yaml
@@ -15,222 +15,96 @@ state:
   characters:
   - id: Patient A
     name: Patient A
-    unstructured: 'massive bleeding from their left groin
+    unstructured: 'massive bleeding from their abdomen
 
-      a foreign civilian with no ties to the military.'
-    medical_condition: 0.98788728
-    attribute_rating: 0.395523466
+      a foreign military ally from a group who has not worked together with your unit.'
+    medical_condition: 0.997658863
+    attribute_rating: 0.687236495
   - id: Patient B
     name: Patient B
-    unstructured: 'massive bleeding from their right arm
+    unstructured: 'no visible bleeding but are not breathing after their airway has
+      been repositioned
 
       a warfighter in the same military unit as you.'
-    medical_condition: 0.979066669
+    medical_condition: 0.917040318
     attribute_rating: 1.0
 scenes:
-- id: Scene 1
-  next_scene: Scene 6
-  end_scene_allowed: false
-  probe_config:
-  - description: Which patient do you treat?
-  state:
-    unstructured: 'Patient A has massive bleeding from their left groin. They are
-      a foreign civilian with no ties to the military.
-
-      Patient B has massive bleeding from their right arm. They are a warfighter in
-      the same military unit as you.
-
-      Which patient do you treat?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: 'massive bleeding from their left groin
-
-        a foreign civilian with no ties to the military.'
-      medical_condition: 0.98788728
-      attribute_rating: 0.395523466
-    - id: Patient B
-      name: Patient B
-      unstructured: 'massive bleeding from their right arm
-
-        a warfighter in the same military unit as you.'
-      medical_condition: 0.979066669
-      attribute_rating: 1.0
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic available at the site of a multi-casualty event and
-        it will be at least 30 minutes before any patient can be evacuated. There
-        are two patients, Patient A and Patient B, and you only have time to treat
-        one of them. You have a small medical field kit with limited supplies.'
-      threats: []
-  action_mapping:
-  - action_id: treat_patient_a
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient A
-    character_id: Patient A
-    probe_id: Probe 8000
-    choice: Response 8000-A
-    kdma_association:
-      medical: 0.98788728
-      affiliation: 0.395523466
-  - action_id: treat_patient_b
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient B
-    probe_id: Probe 8000
-    choice: Response 8000-B
-    kdma_association:
-      medical: 0.979066669
-      affiliation: 1.0
-    character_id: Patient B
-  transitions:
-    probes:
-    - Probe 8000
 - id: Scene 6
-  next_scene: Scene 4
-  end_scene_allowed: false
-  probe_config:
-  - description: Which patient do you treat?
-  state:
-    unstructured: 'Patient A has massive bleeding from their head. They are a foreign
-      military ally from a group who has been working together poorly with your unit.
-
-      Patient B has severe burns on their legs and abdomen, covering 50% of their
-      body. They are a warfighter in the same military unit as you.
-
-      Which patient do you treat?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: 'massive bleeding from their head
-
-        a foreign military ally from a group who has been working together poorly
-        with your unit.'
-      medical_condition: 0.990133779
-      attribute_rating: 0.553240721
-    - id: Patient B
-      name: Patient B
-      unstructured: 'severe burns on their legs and abdomen, covering 50% of their
-        body
-
-        a warfighter in the same military unit as you.'
-      medical_condition: 0.636972142
-      attribute_rating: 1.0
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic available at the site of a multi-casualty event and
-        it will be at least 30 minutes before any patient can be evacuated. There
-        are two patients, Patient A and Patient B, and you only have time to treat
-        one of them. You have a small medical field kit with limited supplies.'
-      threats: []
-  action_mapping:
-  - action_id: treat_patient_a
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient A
-    character_id: Patient A
-    probe_id: Probe 8005
-    choice: Response 8005-A
-    kdma_association:
-      medical: 0.990133779
-      affiliation: 0.553240721
-  - action_id: treat_patient_b
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient B
-    probe_id: Probe 8005
-    choice: Response 8005-B
-    kdma_association:
-      medical: 0.636972142
-      affiliation: 1.0
-    character_id: Patient B
-  transitions:
-    probes:
-    - Probe 8005
-- id: Scene 4
-  next_scene: Scene 3
-  end_scene_allowed: false
-  probe_config:
-  - description: Which patient do you treat?
-  state:
-    unstructured: 'Patient A has moderate bleeding from their left shoulder. They
-      are a POW who just recently surrendered.
-
-      Patient B has a compound fracture below their right knee with mild bleeding.
-      They are a warfighter in the same military unit as you.
-
-      Which patient do you treat?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: 'moderate bleeding from their left shoulder
-
-        a POW who just recently surrendered.'
-      medical_condition: 0.588337499
-      attribute_rating: 0.0
-    - id: Patient B
-      name: Patient B
-      unstructured: 'a compound fracture below their right knee with mild bleeding
-
-        a warfighter in the same military unit as you.'
-      medical_condition: 0.405017641
-      attribute_rating: 1.0
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic available at the site of a multi-casualty event and
-        it will be at least 30 minutes before any patient can be evacuated. There
-        are two patients, Patient A and Patient B, and you only have time to treat
-        one of them. You have a small medical field kit with limited supplies.'
-      threats: []
-  action_mapping:
-  - action_id: treat_patient_a
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient A
-    character_id: Patient A
-    probe_id: Probe 8003
-    choice: Response 8003-A
-    kdma_association:
-      medical: 0.588337499
-      affiliation: 0.0
-  - action_id: treat_patient_b
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient B
-    probe_id: Probe 8003
-    choice: Response 8003-B
-    kdma_association:
-      medical: 0.405017641
-      affiliation: 1.0
-    character_id: Patient B
-  transitions:
-    probes:
-    - Probe 8003
-- id: Scene 3
   next_scene: Scene 2
   end_scene_allowed: false
   probe_config:
   - description: Which patient do you treat?
   state:
-    unstructured: 'Patient A has massive bleeding from their right calf. They are
-      a warfighter in the same branch of the military as you, but not in the same
-      unit.
+    unstructured: 'Patient A has a chest wound and are gasping for breath. They are
+      a US warfighter from a different branch of the military than you.
 
-      Patient B has moderate bleeding from their torso, with possible internal bleeding.
-      They are a warfighter in the same military unit as you.
+      Patient B has started showing signs of compensated shock (high heart rate, fast
+      breathing). Their bleeding was stopped after a large blood loss. They are a
+      warfighter in the same military unit as you.
+
+      Which patient do you treat?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: 'a chest wound and are gasping for breath
+
+        a US warfighter from a different branch of the military than you.'
+      medical_condition: 0.942062369
+      attribute_rating: 0.92
+    - id: Patient B
+      name: Patient B
+      unstructured: 'started showing signs of compensated shock (high heart rate,
+        fast breathing). Their bleeding was stopped after a large blood loss
+
+        a warfighter in the same military unit as you.'
+      medical_condition: 0.64265041
+      attribute_rating: 1.0
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic available at the site of a multi-casualty event and
+        it will be at least 30 minutes before any patient can be evacuated. There
+        are two patients, Patient A and Patient B, and you only have time to treat
+        one of them. You have a small medical field kit with limited supplies.'
+      threats: []
+  action_mapping:
+  - action_id: treat_patient_a
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient A
+    character_id: Patient A
+    probe_id: Probe 3656
+    choice: Response 3656-A
+    kdma_association:
+      medical: 0.942062369
+      affiliation: 0.92
+  - action_id: treat_patient_b
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient B
+    probe_id: Probe 3656
+    choice: Response 3656-B
+    kdma_association:
+      medical: 0.64265041
+      affiliation: 1.0
+    character_id: Patient B
+  transitions:
+    probes:
+    - Probe 3656
+- id: Scene 2
+  next_scene: Scene 4
+  end_scene_allowed: false
+  probe_config:
+  - description: Which patient do you treat?
+  state:
+    unstructured: 'Patient A has massive bleeding from their right calf. They are
+      a US warfighter from a different branch of the military than you.
+
+      Patient B has severe burns on their left arm and torso, covering 20% of their
+      body. They are a warfighter in the same military unit as you.
 
       Which patient do you treat?'
     characters:
@@ -238,77 +112,13 @@ scenes:
       name: Patient A
       unstructured: 'massive bleeding from their right calf
 
-        a warfighter in the same branch of the military as you, but not in the same
-        unit.'
+        a US warfighter from a different branch of the military than you.'
       medical_condition: 0.979066669
-      attribute_rating: 0.95505618
+      attribute_rating: 0.92
     - id: Patient B
       name: Patient B
-      unstructured: 'moderate bleeding from their torso, with possible internal bleeding
-
-        a warfighter in the same military unit as you.'
-      medical_condition: 0.598228527
-      attribute_rating: 1.0
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic available at the site of a multi-casualty event and
-        it will be at least 30 minutes before any patient can be evacuated. There
-        are two patients, Patient A and Patient B, and you only have time to treat
-        one of them. You have a small medical field kit with limited supplies.'
-      threats: []
-  action_mapping:
-  - action_id: treat_patient_a
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient A
-    character_id: Patient A
-    probe_id: Probe 8002
-    choice: Response 8002-A
-    kdma_association:
-      medical: 0.979066669
-      affiliation: 0.95505618
-  - action_id: treat_patient_b
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient B
-    probe_id: Probe 8002
-    choice: Response 8002-B
-    kdma_association:
-      medical: 0.598228527
-      affiliation: 1.0
-    character_id: Patient B
-  transitions:
-    probes:
-    - Probe 8002
-- id: Scene 2
-  next_scene: Scene 5
-  end_scene_allowed: false
-  probe_config:
-  - description: Which patient do you treat?
-  state:
-    unstructured: 'Patient A has moderate bleeding from their groin. They are a foreign
-      military ally from a group who has not worked together with your unit.
-
-      Patient B has severe burns on their left leg, covering 20% of their body. They
-      are a warfighter in the same military unit as you.
-
-      Which patient do you treat?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: 'moderate bleeding from their groin
-
-        a foreign military ally from a group who has not worked together with your
-        unit.'
-      medical_condition: 0.588337499
-      attribute_rating: 0.687236495
-    - id: Patient B
-      name: Patient B
-      unstructured: 'severe burns on their left leg, covering 20% of their body
+      unstructured: 'severe burns on their left arm and torso, covering 20% of their
+        body
 
         a warfighter in the same military unit as you.'
       medical_condition: 0.527059061
@@ -331,32 +141,96 @@ scenes:
     action_type: TREAT_PATIENT
     unstructured: Treat Patient A
     character_id: Patient A
-    probe_id: Probe 8001
-    choice: Response 8001-A
+    probe_id: Probe 3007
+    choice: Response 3007-A
     kdma_association:
-      medical: 0.588337499
-      affiliation: 0.687236495
+      medical: 0.979066669
+      affiliation: 0.92
   - action_id: treat_patient_b
     action_type: TREAT_PATIENT
     unstructured: Treat Patient B
-    probe_id: Probe 8001
-    choice: Response 8001-B
+    probe_id: Probe 3007
+    choice: Response 3007-B
     kdma_association:
       medical: 0.527059061
       affiliation: 1.0
     character_id: Patient B
   transitions:
     probes:
-    - Probe 8001
-- id: Scene 5
-  next_scene: __END_SCENARIO__
+    - Probe 3007
+- id: Scene 4
+  next_scene: Scene 3
   end_scene_allowed: false
   probe_config:
   - description: Which patient do you treat?
   state:
-    unstructured: 'Patient A has severe burns on their legs and abdomen, covering
-      50% of their body. They are a foreign military ally from a group who has been
-      working together well with your unit.
+    unstructured: 'Patient A has no visible bleeding but are not breathing after their
+      airway has been repositioned. They are a POW who was captured over a year ago.
+
+      Patient B has moderate bleeding from their left shoulder. They are a warfighter
+      in the same military unit as you.
+
+      Which patient do you treat?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: 'no visible bleeding but are not breathing after their airway
+        has been repositioned
+
+        a POW who was captured over a year ago.'
+      medical_condition: 0.917040318
+      attribute_rating: 0.142857143
+    - id: Patient B
+      name: Patient B
+      unstructured: 'moderate bleeding from their left shoulder
+
+        a warfighter in the same military unit as you.'
+      medical_condition: 0.588337499
+      attribute_rating: 1.0
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic available at the site of a multi-casualty event and
+        it will be at least 30 minutes before any patient can be evacuated. There
+        are two patients, Patient A and Patient B, and you only have time to treat
+        one of them. You have a small medical field kit with limited supplies.'
+      threats: []
+  action_mapping:
+  - action_id: treat_patient_a
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient A
+    character_id: Patient A
+    probe_id: Probe 3013
+    choice: Response 3013-A
+    kdma_association:
+      medical: 0.917040318
+      affiliation: 0.142857143
+  - action_id: treat_patient_b
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient B
+    probe_id: Probe 3013
+    choice: Response 3013-B
+    kdma_association:
+      medical: 0.588337499
+      affiliation: 1.0
+    character_id: Patient B
+  transitions:
+    probes:
+    - Probe 3013
+- id: Scene 3
+  next_scene: Scene 5
+  end_scene_allowed: false
+  probe_config:
+  - description: Which patient do you treat?
+  state:
+    unstructured: 'Patient A has severe burns on their back, covering 20% of their
+      body. They are a warfighter in the same branch of the military as you, but not
+      in the same unit.
 
       Patient B has a compound fracture of their left leg with mild bleeding. They
       are a warfighter in the same military unit as you.
@@ -365,13 +239,12 @@ scenes:
     characters:
     - id: Patient A
       name: Patient A
-      unstructured: 'severe burns on their legs and abdomen, covering 50% of their
-        body
+      unstructured: 'severe burns on their back, covering 20% of their body
 
-        a foreign military ally from a group who has been working together well with
-        your unit.'
-      medical_condition: 0.636972142
-      attribute_rating: 0.825276404
+        a warfighter in the same branch of the military as you, but not in the same
+        unit.'
+      medical_condition: 0.527059061
+      attribute_rating: 0.95505618
     - id: Patient B
       name: Patient B
       unstructured: 'a compound fracture of their left leg with mild bleeding
@@ -397,20 +270,150 @@ scenes:
     action_type: TREAT_PATIENT
     unstructured: Treat Patient A
     character_id: Patient A
-    probe_id: Probe 8004
-    choice: Response 8004-A
+    probe_id: Probe 3010
+    choice: Response 3010-A
     kdma_association:
-      medical: 0.636972142
-      affiliation: 0.825276404
+      medical: 0.527059061
+      affiliation: 0.95505618
   - action_id: treat_patient_b
     action_type: TREAT_PATIENT
     unstructured: Treat Patient B
-    probe_id: Probe 8004
-    choice: Response 8004-B
+    probe_id: Probe 3010
+    choice: Response 3010-B
     kdma_association:
       medical: 0.405017641
       affiliation: 1.0
     character_id: Patient B
   transitions:
     probes:
-    - Probe 8004
+    - Probe 3010
+- id: Scene 5
+  next_scene: Scene 1
+  end_scene_allowed: false
+  probe_config:
+  - description: Which patient do you treat?
+  state:
+    unstructured: 'Patient A has massive bleeding from a partial amputation of their
+      left hand. They are a foreign civilian contractor who works for the US military,
+      but not your unit.
+
+      Patient B has moderate bleeding from their left hip. They are a warfighter in
+      the same military unit as you.
+
+      Which patient do you treat?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: 'massive bleeding from a partial amputation of their left hand
+
+        a foreign civilian contractor who works for the US military, but not your
+        unit.'
+      medical_condition: 0.979066669
+      attribute_rating: 0.553598635
+    - id: Patient B
+      name: Patient B
+      unstructured: 'moderate bleeding from their left hip
+
+        a warfighter in the same military unit as you.'
+      medical_condition: 0.588337499
+      attribute_rating: 1.0
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic available at the site of a multi-casualty event and
+        it will be at least 30 minutes before any patient can be evacuated. There
+        are two patients, Patient A and Patient B, and you only have time to treat
+        one of them. You have a small medical field kit with limited supplies.'
+      threats: []
+  action_mapping:
+  - action_id: treat_patient_a
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient A
+    character_id: Patient A
+    probe_id: Probe 3020
+    choice: Response 3020-A
+    kdma_association:
+      medical: 0.979066669
+      affiliation: 0.553598635
+  - action_id: treat_patient_b
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient B
+    probe_id: Probe 3020
+    choice: Response 3020-B
+    kdma_association:
+      medical: 0.588337499
+      affiliation: 1.0
+    character_id: Patient B
+  transitions:
+    probes:
+    - Probe 3020
+- id: Scene 1
+  next_scene: __END_SCENARIO__
+  end_scene_allowed: false
+  probe_config:
+  - description: Which patient do you treat?
+  state:
+    unstructured: 'Patient A has massive bleeding from their abdomen. They are a foreign
+      military ally from a group who has not worked together with your unit.
+
+      Patient B has no visible bleeding but are not breathing after their airway has
+      been repositioned. They are a warfighter in the same military unit as you.
+
+      Which patient do you treat?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: 'massive bleeding from their abdomen
+
+        a foreign military ally from a group who has not worked together with your
+        unit.'
+      medical_condition: 0.997658863
+      attribute_rating: 0.687236495
+    - id: Patient B
+      name: Patient B
+      unstructured: 'no visible bleeding but are not breathing after their airway
+        has been repositioned
+
+        a warfighter in the same military unit as you.'
+      medical_condition: 0.917040318
+      attribute_rating: 1.0
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic available at the site of a multi-casualty event and
+        it will be at least 30 minutes before any patient can be evacuated. There
+        are two patients, Patient A and Patient B, and you only have time to treat
+        one of them. You have a small medical field kit with limited supplies.'
+      threats: []
+  action_mapping:
+  - action_id: treat_patient_a
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient A
+    character_id: Patient A
+    probe_id: Probe 3001
+    choice: Response 3001-A
+    kdma_association:
+      medical: 0.997658863
+      affiliation: 0.687236495
+  - action_id: treat_patient_b
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient B
+    probe_id: Probe 3001
+    choice: Response 3001-B
+    kdma_association:
+      medical: 0.917040318
+      affiliation: 1.0
+    character_id: Patient B
+  transitions:
+    probes:
+    - Probe 3001

--- a/phase2/june2026/assess/june2026-adept-assess-MF.yaml
+++ b/phase2/june2026/assess/june2026-adept-assess-MF.yaml
@@ -15,306 +15,47 @@ state:
   characters:
   - id: Patient A
     name: Patient A
-    unstructured: 'massive bleeding from their right shoulder
+    unstructured: 'no visible bleeding but are not breathing
 
-      abandoned their military duty station during a high threat condition, so there
-      was no warning for an enemy attack that seriously injured 2 people.'
-    medical_condition: 0.98788728
-    attribute_rating: 0.2545
+      started a fist fight where both people were seriously injured in the fight.'
+    medical_condition: 0.947157191
+    attribute_rating: 0.55
   - id: Patient B
     name: Patient B
-    unstructured: 'massive bleeding from their left calf
+    unstructured: 'severe burns on their legs and abdomen, covering 50% of their body
 
-      were injured in the attack.'
-    medical_condition: 0.979066669
+      were injured in the fight.'
+    medical_condition: 0.636972142
     attribute_rating: 1.0
 scenes:
-- id: Scene 4
-  next_scene: Scene 1
-  end_scene_allowed: false
-  probe_config:
-  - description: Which patient do you treat?
-  state:
-    unstructured: 'Patient A has moderate bleeding from their right shoulder. They
-      are a mass shooter who killed 1 person and seriously injured 5 people at a festival.
-
-      Patient B has a compound fracture below their left knee with mild bleeding.
-      They are a victim in the shooting.
-
-      Which patient do you treat?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: 'moderate bleeding from their right shoulder
-
-        are a mass shooter who killed 1 person and seriously injured 5 people at a
-        festival.'
-      medical_condition: 0.588337499
-      attribute_rating: 0.0
-    - id: Patient B
-      name: Patient B
-      unstructured: 'a compound fracture below their left knee with mild bleeding
-
-        are a victim in the shooting.'
-      medical_condition: 0.405017641
-      attribute_rating: 1.0
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic available at the site of a multi-casualty event and
-        it will be at least 30 minutes before any patient can be evacuated. There
-        are two patients, Patient A and Patient B, and you only have time to treat
-        one of them. You have a small medical field kit with limited supplies.'
-      threats: []
-  action_mapping:
-  - action_id: treat_patient_a
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient A
-    character_id: Patient A
-    probe_id: Probe 9003
-    choice: Response 9003-A
-    kdma_association:
-      medical: 0.588337499
-      merit: 0.0
-  - action_id: treat_patient_b
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient B
-    probe_id: Probe 9003
-    choice: Response 9003-B
-    kdma_association:
-      medical: 0.405017641
-      merit: 1.0
-    character_id: Patient B
-  transitions:
-    probes:
-    - Probe 9003
 - id: Scene 1
-  next_scene: Scene 3
-  end_scene_allowed: false
-  probe_config:
-  - description: Which patient do you treat?
-  state:
-    unstructured: 'Patient A has massive bleeding from their right shoulder. They
-      abandoned their military duty station during a high threat condition, so there
-      was no warning for an enemy attack that seriously injured 2 people.
-
-      Patient B has massive bleeding from their left calf. They were injured in the
-      attack.
-
-      Which patient do you treat?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: 'massive bleeding from their right shoulder
-
-        abandoned their military duty station during a high threat condition, so there
-        was no warning for an enemy attack that seriously injured 2 people.'
-      medical_condition: 0.98788728
-      attribute_rating: 0.2545
-    - id: Patient B
-      name: Patient B
-      unstructured: 'massive bleeding from their left calf
-
-        were injured in the attack.'
-      medical_condition: 0.979066669
-      attribute_rating: 1.0
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic available at the site of a multi-casualty event and
-        it will be at least 30 minutes before any patient can be evacuated. There
-        are two patients, Patient A and Patient B, and you only have time to treat
-        one of them. You have a small medical field kit with limited supplies.'
-      threats: []
-  action_mapping:
-  - action_id: treat_patient_a
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient A
-    character_id: Patient A
-    probe_id: Probe 9000
-    choice: Response 9000-A
-    kdma_association:
-      medical: 0.98788728
-      merit: 0.2545
-  - action_id: treat_patient_b
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient B
-    probe_id: Probe 9000
-    choice: Response 9000-B
-    kdma_association:
-      medical: 0.979066669
-      merit: 1.0
-    character_id: Patient B
-  transitions:
-    probes:
-    - Probe 9000
-- id: Scene 3
-  next_scene: Scene 2
-  end_scene_allowed: false
-  probe_config:
-  - description: Which patient do you treat?
-  state:
-    unstructured: 'Patient A has massive bleeding from their left calf. They accidentally
-      discharged their weapon, seriously injuring 2 people.
-
-      Patient B has moderate bleeding from their abdomen, with possible internal bleeding.
-      They are a bystander who was injured.
-
-      Which patient do you treat?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: 'massive bleeding from their left calf
-
-        accidentally discharged their weapon, seriously injuring 2 people.'
-      medical_condition: 0.979066669
-      attribute_rating: 0.8825
-    - id: Patient B
-      name: Patient B
-      unstructured: 'moderate bleeding from their abdomen, with possible internal
-        bleeding
-
-        are a bystander who was injured.'
-      medical_condition: 0.598228527
-      attribute_rating: 1.0
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic available at the site of a multi-casualty event and
-        it will be at least 30 minutes before any patient can be evacuated. There
-        are two patients, Patient A and Patient B, and you only have time to treat
-        one of them. You have a small medical field kit with limited supplies.'
-      threats: []
-  action_mapping:
-  - action_id: treat_patient_a
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient A
-    character_id: Patient A
-    probe_id: Probe 9002
-    choice: Response 9002-A
-    kdma_association:
-      medical: 0.979066669
-      merit: 0.8825
-  - action_id: treat_patient_b
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient B
-    probe_id: Probe 9002
-    choice: Response 9002-B
-    kdma_association:
-      medical: 0.598228527
-      merit: 1.0
-    character_id: Patient B
-  transitions:
-    probes:
-    - Probe 9002
-- id: Scene 2
-  next_scene: Scene 6
-  end_scene_allowed: false
-  probe_config:
-  - description: Which patient do you treat?
-  state:
-    unstructured: 'Patient A has moderate bleeding from their left shoulder. They
-      abandoned their military duty station during a low threat condition, so there
-      was no warning for an enemy attack that seriously injured 2 people.
-
-      Patient B has severe burns on their back, covering 20% of their body. They were
-      injured in the attack.
-
-      Which patient do you treat?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: 'moderate bleeding from their left shoulder
-
-        abandoned their military duty station during a low threat condition, so there
-        was no warning for an enemy attack that seriously injured 2 people.'
-      medical_condition: 0.588337499
-      attribute_rating: 0.444
-    - id: Patient B
-      name: Patient B
-      unstructured: 'severe burns on their back, covering 20% of their body
-
-        were injured in the attack.'
-      medical_condition: 0.527059061
-      attribute_rating: 1.0
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic available at the site of a multi-casualty event and
-        it will be at least 30 minutes before any patient can be evacuated. There
-        are two patients, Patient A and Patient B, and you only have time to treat
-        one of them. You have a small medical field kit with limited supplies.'
-      threats: []
-  action_mapping:
-  - action_id: treat_patient_a
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient A
-    character_id: Patient A
-    probe_id: Probe 9001
-    choice: Response 9001-A
-    kdma_association:
-      medical: 0.588337499
-      merit: 0.444
-  - action_id: treat_patient_b
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient B
-    probe_id: Probe 9001
-    choice: Response 9001-B
-    kdma_association:
-      medical: 0.527059061
-      merit: 1.0
-    character_id: Patient B
-  transitions:
-    probes:
-    - Probe 9001
-- id: Scene 6
   next_scene: Scene 5
   end_scene_allowed: false
   probe_config:
   - description: Which patient do you treat?
   state:
-    unstructured: 'Patient A has severe burns on their left arm and torso, covering
-      20% of their body. They detonated a small IED, seriously injuring 2 people.
+    unstructured: 'Patient A has no visible bleeding but are not breathing. They started
+      a fist fight where both people were seriously injured in the fight.
 
-      Patient B has a broken right ankle with no bleeding. They are a bystander who
-      was injured.
+      Patient B has severe burns on their legs and abdomen, covering 50% of their
+      body. They were injured in the fight.
 
       Which patient do you treat?'
     characters:
     - id: Patient A
       name: Patient A
-      unstructured: 'severe burns on their left arm and torso, covering 20% of their
-        body
+      unstructured: 'no visible bleeding but are not breathing
 
-        detonated a small IED, seriously injuring 2 people.'
-      medical_condition: 0.527059061
-      attribute_rating: 0.1505
+        started a fist fight where both people were seriously injured in the fight.'
+      medical_condition: 0.947157191
+      attribute_rating: 0.55
     - id: Patient B
       name: Patient B
-      unstructured: 'a broken right ankle with no bleeding
+      unstructured: 'severe burns on their legs and abdomen, covering 50% of their
+        body
 
-        are a bystander who was injured.'
-      medical_condition: 0.012495865
+        were injured in the fight.'
+      medical_condition: 0.636972142
       attribute_rating: 1.0
     threat_state:
       unstructured: 'Imagine that you are deployed as a military medic in a foreign
@@ -334,52 +75,308 @@ scenes:
     action_type: TREAT_PATIENT
     unstructured: Treat Patient A
     character_id: Patient A
-    probe_id: Probe 9006
-    choice: Response 9006-A
+    probe_id: Probe 1004
+    choice: Response 1004-A
     kdma_association:
-      medical: 0.527059061
-      merit: 0.1505
+      medical: 0.947157191
+      merit: 0.55
   - action_id: treat_patient_b
     action_type: TREAT_PATIENT
     unstructured: Treat Patient B
-    probe_id: Probe 9006
-    choice: Response 9006-B
+    probe_id: Probe 1004
+    choice: Response 1004-B
     kdma_association:
-      medical: 0.012495865
+      medical: 0.636972142
       merit: 1.0
     character_id: Patient B
   transitions:
     probes:
-    - Probe 9006
+    - Probe 1004
 - id: Scene 5
+  next_scene: Scene 2
+  end_scene_allowed: false
+  probe_config:
+  - description: Which patient do you treat?
+  state:
+    unstructured: 'Patient A has a chest wound and are gasping for breath. They detonated
+      a large IED, killing 1 person and seriously injuring 5 people.
+
+      Patient B has moderate bleeding from their right bicep. They are a bystander
+      who was injured.
+
+      Which patient do you treat?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: 'a chest wound and are gasping for breath
+
+        detonated a large IED, killing 1 person and seriously injuring 5 people.'
+      medical_condition: 0.942062369
+      attribute_rating: 0.07
+    - id: Patient B
+      name: Patient B
+      unstructured: 'moderate bleeding from their right bicep
+
+        are a bystander who was injured.'
+      medical_condition: 0.588337499
+      attribute_rating: 1.0
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic available at the site of a multi-casualty event and
+        it will be at least 30 minutes before any patient can be evacuated. There
+        are two patients, Patient A and Patient B, and you only have time to treat
+        one of them. You have a small medical field kit with limited supplies.'
+      threats: []
+  action_mapping:
+  - action_id: treat_patient_a
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient A
+    character_id: Patient A
+    probe_id: Probe 1024
+    choice: Response 1024-A
+    kdma_association:
+      medical: 0.942062369
+      merit: 0.07
+  - action_id: treat_patient_b
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient B
+    probe_id: Probe 1024
+    choice: Response 1024-B
+    kdma_association:
+      medical: 0.588337499
+      merit: 1.0
+    character_id: Patient B
+  transitions:
+    probes:
+    - Probe 1024
+- id: Scene 2
+  next_scene: Scene 4
+  end_scene_allowed: false
+  probe_config:
+  - description: Which patient do you treat?
+  state:
+    unstructured: 'Patient A has massive bleeding from their head. They detonated
+      a small IED, seriously injuring 2 people.
+
+      Patient B has moderate bleeding from their left shoulder. They are a bystander
+      who was injured.
+
+      Which patient do you treat?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: 'massive bleeding from their head
+
+        detonated a small IED, seriously injuring 2 people.'
+      medical_condition: 0.990133779
+      attribute_rating: 0.1505
+    - id: Patient B
+      name: Patient B
+      unstructured: 'moderate bleeding from their left shoulder
+
+        are a bystander who was injured.'
+      medical_condition: 0.588337499
+      attribute_rating: 1.0
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic available at the site of a multi-casualty event and
+        it will be at least 30 minutes before any patient can be evacuated. There
+        are two patients, Patient A and Patient B, and you only have time to treat
+        one of them. You have a small medical field kit with limited supplies.'
+      threats: []
+  action_mapping:
+  - action_id: treat_patient_a
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient A
+    character_id: Patient A
+    probe_id: Probe 1006
+    choice: Response 1006-A
+    kdma_association:
+      medical: 0.990133779
+      merit: 0.1505
+  - action_id: treat_patient_b
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient B
+    probe_id: Probe 1006
+    choice: Response 1006-B
+    kdma_association:
+      medical: 0.588337499
+      merit: 1.0
+    character_id: Patient B
+  transitions:
+    probes:
+    - Probe 1006
+- id: Scene 4
+  next_scene: Scene 3
+  end_scene_allowed: false
+  probe_config:
+  - description: Which patient do you treat?
+  state:
+    unstructured: 'Patient A has massive bleeding from a partial amputation of their
+      left foot. They put a smoke grenade into a tent as a joke and seriously injured
+      2 people.
+
+      Patient B has a chest wound and are gasping for breath. They were injured in
+      the accident.
+
+      Which patient do you treat?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: 'massive bleeding from a partial amputation of their left foot
+
+        put a smoke grenade into a tent as a joke and seriously injured 2 people.'
+      medical_condition: 0.979066669
+      attribute_rating: 0.67
+    - id: Patient B
+      name: Patient B
+      unstructured: 'a chest wound and are gasping for breath
+
+        were injured in the accident.'
+      medical_condition: 0.942062369
+      attribute_rating: 1.0
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic available at the site of a multi-casualty event and
+        it will be at least 30 minutes before any patient can be evacuated. There
+        are two patients, Patient A and Patient B, and you only have time to treat
+        one of them. You have a small medical field kit with limited supplies.'
+      threats: []
+  action_mapping:
+  - action_id: treat_patient_a
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient A
+    character_id: Patient A
+    probe_id: Probe 1021
+    choice: Response 1021-A
+    kdma_association:
+      medical: 0.979066669
+      merit: 0.67
+  - action_id: treat_patient_b
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient B
+    probe_id: Probe 1021
+    choice: Response 1021-B
+    kdma_association:
+      medical: 0.942062369
+      merit: 1.0
+    character_id: Patient B
+  transitions:
+    probes:
+    - Probe 1021
+- id: Scene 3
+  next_scene: Scene 6
+  end_scene_allowed: false
+  probe_config:
+  - description: Which patient do you treat?
+  state:
+    unstructured: 'Patient A has started showing signs of compensated shock (high
+      heart rate, fast breathing). Their bleeding was stopped after a large blood
+      loss. They are a drunk driver who hit a bus, killing 1 person and seriously
+      injuring 5 people.
+
+      Patient B has moderate bleeding from their left bicep. They were injured in
+      the crash.
+
+      Which patient do you treat?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: 'started showing signs of compensated shock (high heart rate,
+        fast breathing). Their bleeding was stopped after a large blood loss
+
+        are a drunk driver who hit a bus, killing 1 person and seriously injuring
+        5 people.'
+      medical_condition: 0.64265041
+      attribute_rating: 0.3295
+    - id: Patient B
+      name: Patient B
+      unstructured: 'moderate bleeding from their left bicep
+
+        were injured in the crash.'
+      medical_condition: 0.588337499
+      attribute_rating: 1.0
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic available at the site of a multi-casualty event and
+        it will be at least 30 minutes before any patient can be evacuated. There
+        are two patients, Patient A and Patient B, and you only have time to treat
+        one of them. You have a small medical field kit with limited supplies.'
+      threats: []
+  action_mapping:
+  - action_id: treat_patient_a
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient A
+    character_id: Patient A
+    probe_id: Probe 1016
+    choice: Response 1016-A
+    kdma_association:
+      medical: 0.64265041
+      merit: 0.3295
+  - action_id: treat_patient_b
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient B
+    probe_id: Probe 1016
+    choice: Response 1016-B
+    kdma_association:
+      medical: 0.588337499
+      merit: 1.0
+    character_id: Patient B
+  transitions:
+    probes:
+    - Probe 1016
+- id: Scene 6
   next_scene: __END_SCENARIO__
   end_scene_allowed: false
   probe_config:
   - description: Which patient do you treat?
   state:
-    unstructured: 'Patient A has severe burns on their arms and back, covering 50%
-      of their body. They started a fist fight where both people were seriously injured
-      from a wall collapsing after they ran into it.
+    unstructured: 'Patient A has a chest wound and are gasping for breath. They are
+      a drunk driver who hit a bus, killing 1 person and seriously injuring 5 people.
 
-      Patient B has a compound fracture of their right leg with mild bleeding. They
-      were injured by the wall.
+      Patient B has moderate bleeding from their left forearm. They were injured in
+      the crash.
 
       Which patient do you treat?'
     characters:
     - id: Patient A
       name: Patient A
-      unstructured: 'severe burns on their arms and back, covering 50% of their body
+      unstructured: 'a chest wound and are gasping for breath
 
-        started a fist fight where both people were seriously injured from a wall
-        collapsing after they ran into it.'
-      medical_condition: 0.636972142
-      attribute_rating: 0.5575
+        are a drunk driver who hit a bus, killing 1 person and seriously injuring
+        5 people.'
+      medical_condition: 0.942062369
+      attribute_rating: 0.3295
     - id: Patient B
       name: Patient B
-      unstructured: 'a compound fracture of their right leg with mild bleeding
+      unstructured: 'moderate bleeding from their left forearm
 
-        were injured by the wall.'
-      medical_condition: 0.405017641
+        were injured in the crash.'
+      medical_condition: 0.588337499
       attribute_rating: 1.0
     threat_state:
       unstructured: 'Imagine that you are deployed as a military medic in a foreign
@@ -399,20 +396,20 @@ scenes:
     action_type: TREAT_PATIENT
     unstructured: Treat Patient A
     character_id: Patient A
-    probe_id: Probe 9004
-    choice: Response 9004-A
+    probe_id: Probe 1030
+    choice: Response 1030-A
     kdma_association:
-      medical: 0.636972142
-      merit: 0.5575
+      medical: 0.942062369
+      merit: 0.3295
   - action_id: treat_patient_b
     action_type: TREAT_PATIENT
     unstructured: Treat Patient B
-    probe_id: Probe 9004
-    choice: Response 9004-B
+    probe_id: Probe 1030
+    choice: Response 1030-B
     kdma_association:
-      medical: 0.405017641
+      medical: 0.588337499
       merit: 1.0
     character_id: Patient B
   transitions:
     probes:
-    - Probe 9004
+    - Probe 1030

--- a/phase2/june2026/assess/june2026-adept-assess-PS.yaml
+++ b/phase2/june2026/assess/june2026-adept-assess-PS.yaml
@@ -13,35 +13,38 @@ state:
   characters:
   - id: Patient A
     name: Patient A
-    unstructured: The casualty is in an exposed location and you would need to move
-      across 100 ft of exposed area to reach them. They may have a broken leg.
-    medical_condition: 0.074666667
-    attribute_rating: 0.517996623
+    unstructured: The casualty is in a location with cover, but you would need to
+      move across 20 ft of exposed area to reach them. They are screaming, but you
+      can't see their injury.
+    medical_condition: 0.312888889
+    attribute_rating: 0.905918476
 scenes:
-- id: Scene 6
-  next_scene: Scene 2
+- id: Scene 1
+  next_scene: Scene 5
   end_scene_allowed: true
   probe_config:
   - description: You are currently in a location with cover. Do you move to treat
       the casualty now, or wait in your current location?
   state:
-    unstructured: 'During a company advance to contact, you make contact with a comparable
-      enemy force and sustain one casualty. Your company successfully calls in supporting
-      arms against the enemy location. You have not received any additional fire in
-      the last 2 minutes.
+    unstructured: 'During a company advance to contact, you made contact with a comparable
+      enemy force and sustained one casualty. Your company successfully called in
+      supporting arms against the enemy location. You have not received any additional
+      fire in the last 2 minutes.
 
-      The casualty is in an exposed location and you would need to move across 100
-      ft of exposed area to reach them. They are bleeding heavily.
+      The casualty is in a location with cover, but you would need to move across
+      20 ft of exposed area to reach them. They are screaming, but you can''t see
+      their injury.
 
       You are currently in a location with cover. Do you move to treat the casualty
       now, or wait in your current location?'
     characters:
     - id: Patient A
       name: Patient A
-      unstructured: The casualty is in an exposed location and you would need to move
-        across 100 ft of exposed area to reach them. They are bleeding heavily.
-      medical_condition: 0.781777778
-      attribute_rating: 0.567196527
+      unstructured: The casualty is in a location with cover, but you would need to
+        move across 20 ft of exposed area to reach them. They are screaming, but you
+        can't see their injury.
+      medical_condition: 0.312888889
+      attribute_rating: 0.905918476
     threat_state:
       unstructured: 'Imagine that you are deployed as a military medic in a foreign
         country where there is ongoing warfare. In the last few months, your military
@@ -59,22 +62,140 @@ scenes:
     action_type: TREAT_PATIENT
     unstructured: Move to treat the casualty now
     character_id: Patient A
-    probe_id: Probe 5015
-    choice: Response 5015-A
+    probe_id: Probe 5113
+    choice: Response 5113-A
     kdma_association:
-      medical: 0.781777778
-      personal_safety: 0.567196527
+      medical: 0.312888889
+      personal_safety: 0.905918476
   - action_id: wait_in_your_current_location
     action_type: END_SCENE
     unstructured: Wait in your current location
-    probe_id: Probe 5015
-    choice: Response 5015-B
+    probe_id: Probe 5113
+    choice: Response 5113-B
     kdma_association:
       medical: 0.0
       personal_safety: 1.0
   transitions:
     probes:
-    - Probe 5015
+    - Probe 5113
+- id: Scene 5
+  next_scene: Scene 3
+  end_scene_allowed: true
+  probe_config:
+  - description: You are currently in a location with cover. Do you move to treat
+      the casualty now, or wait in your current location?
+  state:
+    unstructured: 'Your squad was patrolling dismounted when it received fire from
+      a sniper and sustained one casualty. Your unit does not have a good idea of
+      the suspected sniper location. You have not received any additional fire in
+      the last 5 minutes.
+
+      The casualty is in a location with cover, but you would need to move across
+      100 ft of exposed area to reach them. They are not visible from your location,
+      but you are told they are bleeding a lot.
+
+      You are currently in a location with cover. Do you move to treat the casualty
+      now, or wait in your current location?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: The casualty is in a location with cover, but you would need to
+        move across 100 ft of exposed area to reach them. They are not visible from
+        your location, but you are told they are bleeding a lot.
+      medical_condition: 0.767555556
+      attribute_rating: 0.273130796
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic with your unit. It will be at least 30 minutes before
+        any casualty can be evacuated.  You have a small medical field kit with limited
+        supplies.'
+      threats: []
+  action_mapping:
+  - action_id: move_to_treat_the_casualty_now
+    action_type: TREAT_PATIENT
+    unstructured: Move to treat the casualty now
+    character_id: Patient A
+    probe_id: Probe 5135
+    choice: Response 5135-A
+    kdma_association:
+      medical: 0.767555556
+      personal_safety: 0.273130796
+  - action_id: wait_in_your_current_location
+    action_type: END_SCENE
+    unstructured: Wait in your current location
+    probe_id: Probe 5135
+    choice: Response 5135-B
+    kdma_association:
+      medical: 0.0
+      personal_safety: 1.0
+  transitions:
+    probes:
+    - Probe 5135
+- id: Scene 3
+  next_scene: Scene 2
+  end_scene_allowed: true
+  probe_config:
+  - description: You are currently in a location with cover. Do you move to treat
+      the casualty now, or wait in your current location?
+  state:
+    unstructured: 'Your unit was conducting a mounted patrol on JLTVs when you were
+      ambushed, received small arms and RPG fire, and sustained one casualty. Your
+      unit returned fire at the suspected enemy location. You have not received any
+      additional fire in the last 3 minutes.
+
+      The casualty is in a location with cover, but you would need to move across
+      20 ft of exposed area to reach them. They are not visible from your location,
+      but you are told they aren''t breathing.
+
+      You are currently in a location with cover. Do you move to treat the casualty
+      now, or wait in your current location?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: The casualty is in a location with cover, but you would need to
+        move across 20 ft of exposed area to reach them. They are not visible from
+        your location, but you are told they aren't breathing.
+      medical_condition: 0.764
+      attribute_rating: 0.525639887
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic with your unit. It will be at least 30 minutes before
+        any casualty can be evacuated.  You have a small medical field kit with limited
+        supplies.'
+      threats: []
+  action_mapping:
+  - action_id: move_to_treat_the_casualty_now
+    action_type: TREAT_PATIENT
+    unstructured: Move to treat the casualty now
+    character_id: Patient A
+    probe_id: Probe 5173
+    choice: Response 5173-A
+    kdma_association:
+      medical: 0.764
+      personal_safety: 0.525639887
+  - action_id: wait_in_your_current_location
+    action_type: END_SCENE
+    unstructured: Wait in your current location
+    probe_id: Probe 5173
+    choice: Response 5173-B
+    kdma_association:
+      medical: 0.0
+      personal_safety: 1.0
+  transitions:
+    probes:
+    - Probe 5173
 - id: Scene 2
   next_scene: Scene 4
   end_scene_allowed: true
@@ -82,71 +203,13 @@ scenes:
   - description: You are currently in a location with cover. Do you move to treat
       the casualty now, or wait in your current location?
   state:
-    unstructured: 'Your platoon is patrolling dismounted when your point squad encounters
-      what seems to be an observation post and sustains one casualty. Your squad exchanged
-      fire. Three enemy troops are reported fleeing the location. You have not received
-      any additional fire in the last 2 minutes.
+    unstructured: 'Your squad was patrolling dismounted when it received fire from
+      a sniper and sustained one casualty. The squad leader got a good fix on the
+      sniper''s location and successfully ordered a SMAW fired into that location.
+      You have not received any additional fire in the last 5 minutes.
 
       The casualty is in an exposed location and you would need to move across 100
-      ft of exposed area to reach them. They are not visible from your location.
-
-      You are currently in a location with cover. Do you move to treat the casualty
-      now, or wait in your current location?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: The casualty is in an exposed location and you would need to move
-        across 100 ft of exposed area to reach them. They are not visible from your
-        location.
-      medical_condition: 0.589333333
-      attribute_rating: 0.502424559
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic with your unit. It will be at least 30 minutes before
-        any casualty can be evacuated.  You have a small medical field kit with limited
-        supplies.'
-      threats: []
-  action_mapping:
-  - action_id: move_to_treat_the_casualty_now
-    action_type: TREAT_PATIENT
-    unstructured: Move to treat the casualty now
-    character_id: Patient A
-    probe_id: Probe 5012
-    choice: Response 5012-A
-    kdma_association:
-      medical: 0.589333333
-      personal_safety: 0.502424559
-  - action_id: wait_in_your_current_location
-    action_type: END_SCENE
-    unstructured: Wait in your current location
-    probe_id: Probe 5012
-    choice: Response 5012-B
-    kdma_association:
-      medical: 0.0
-      personal_safety: 1.0
-  transitions:
-    probes:
-    - Probe 5012
-- id: Scene 4
-  next_scene: Scene 5
-  end_scene_allowed: true
-  probe_config:
-  - description: You are currently in a location with cover. Do you move to treat
-      the casualty now, or wait in your current location?
-  state:
-    unstructured: 'During a company advance to contact, you make contact with a comparable
-      enemy force and sustain one casualty. Your company successfully calls in supporting
-      arms against the enemy location. You have not received any additional fire in
-      the last 2 minutes.
-
-      The casualty is in a location with cover, but you would need to move across
-      100 ft of exposed area to reach them. They are calling for help, but you can''t
+      ft of exposed area to reach them. They are calling for a medic, but you can''t
       see their injury.
 
       You are currently in a location with cover. Do you move to treat the casualty
@@ -154,11 +217,11 @@ scenes:
     characters:
     - id: Patient A
       name: Patient A
-      unstructured: The casualty is in a location with cover, but you would need to
-        move across 100 ft of exposed area to reach them. They are calling for help,
+      unstructured: The casualty is in an exposed location and you would need to move
+        across 100 ft of exposed area to reach them. They are calling for a medic,
         but you can't see their injury.
-      medical_condition: 0.381333333
-      attribute_rating: 0.68272728
+      medical_condition: 0.441333333
+      attribute_rating: 0.517996623
     threat_state:
       unstructured: 'Imagine that you are deployed as a military medic in a foreign
         country where there is ongoing warfare. In the last few months, your military
@@ -176,90 +239,33 @@ scenes:
     action_type: TREAT_PATIENT
     unstructured: Move to treat the casualty now
     character_id: Patient A
-    probe_id: Probe 5011
-    choice: Response 5011-A
+    probe_id: Probe 5142
+    choice: Response 5142-A
     kdma_association:
-      medical: 0.381333333
-      personal_safety: 0.68272728
+      medical: 0.441333333
+      personal_safety: 0.517996623
   - action_id: wait_in_your_current_location
     action_type: END_SCENE
     unstructured: Wait in your current location
-    probe_id: Probe 5011
-    choice: Response 5011-B
+    probe_id: Probe 5142
+    choice: Response 5142-B
     kdma_association:
       medical: 0.0
       personal_safety: 1.0
   transitions:
     probes:
-    - Probe 5011
-- id: Scene 5
-  next_scene: Scene 1
+    - Probe 5142
+- id: Scene 4
+  next_scene: Scene 6
   end_scene_allowed: true
   probe_config:
   - description: You are currently in a location with cover. Do you move to treat
       the casualty now, or wait in your current location?
   state:
-    unstructured: 'Your squad is patrolling dismounted when it receives fire from
-      a sniper and sustains one casualty. The squad leader got a good fix on the sniper''s
-      location and successfully ordered a SMAW fired into that location. You have
-      not received any additional fire in the last 5 minutes.
-
-      The casualty is in a location with cover, but you would need to move across
-      20 ft of exposed area to reach them. They are bleeding heavily.
-
-      You are currently in a location with cover. Do you move to treat the casualty
-      now, or wait in your current location?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: The casualty is in a location with cover, but you would need to
-        move across 20 ft of exposed area to reach them. They are bleeding heavily.
-      medical_condition: 0.781777778
-      attribute_rating: 0.865356204
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic with your unit. It will be at least 30 minutes before
-        any casualty can be evacuated.  You have a small medical field kit with limited
-        supplies.'
-      threats: []
-  action_mapping:
-  - action_id: move_to_treat_the_casualty_now
-    action_type: TREAT_PATIENT
-    unstructured: Move to treat the casualty now
-    character_id: Patient A
-    probe_id: Probe 5014
-    choice: Response 5014-A
-    kdma_association:
-      medical: 0.781777778
-      personal_safety: 0.865356204
-  - action_id: wait_in_your_current_location
-    action_type: END_SCENE
-    unstructured: Wait in your current location
-    probe_id: Probe 5014
-    choice: Response 5014-B
-    kdma_association:
-      medical: 0.0
-      personal_safety: 1.0
-  transitions:
-    probes:
-    - Probe 5014
-- id: Scene 1
-  next_scene: Scene 3
-  end_scene_allowed: true
-  probe_config:
-  - description: You are currently in a location with cover. Do you move to treat
-      the casualty now, or wait in your current location?
-  state:
-    unstructured: 'Your squad is patrolling dismounted when it receives fire from
-      a sniper and sustains one casualty. The squad leader got a good fix on the sniper''s
-      location and successfully ordered a SMAW fired into that location. You have
-      not received any additional fire in the last 5 minutes.
+    unstructured: 'Your squad was patrolling dismounted when it received fire from
+      a sniper and sustained one casualty. The squad leader got a good fix on the
+      sniper''s location and successfully ordered a SMAW fired into that location.
+      You have not received any additional fire in the last 5 minutes.
 
       The casualty is in an exposed location and you would need to move across 100
       ft of exposed area to reach them. They may have a broken leg.
@@ -306,22 +312,19 @@ scenes:
   transitions:
     probes:
     - Probe 5008
-- id: Scene 3
+- id: Scene 6
   next_scene: __END_SCENARIO__
   end_scene_allowed: true
   probe_config:
   - description: You are currently in a location with cover. Do you move to treat
       the casualty now, or wait in your current location?
   state:
-    unstructured: 'Your unit is conducting a mounted patrol on JLTVs when you are
-      ambushed, receiving small arms and RPG fire, and sustaining one casualty. Your
-      unit returns fire at the suspected enemy location. About six enemy troops are
-      spotted withdrawing. You have not received any additional fire in the last 3
-      minutes.
+    unstructured: 'In the process of attacking a suspected enemy position, your platoon
+      was pinned down by a heavy volume of fire and sustained one casualty. The enemy
+      fire ceased. You have not received any enemy fire in the last 3 minutes.
 
       The casualty is in a location with cover, but you would need to move across
-      20 ft of exposed area to reach them. They are screaming, but you can''t see
-      their injury.
+      100 ft of exposed area to reach them. They are bleeding heavily.
 
       You are currently in a location with cover. Do you move to treat the casualty
       now, or wait in your current location?'
@@ -329,10 +332,9 @@ scenes:
     - id: Patient A
       name: Patient A
       unstructured: The casualty is in a location with cover, but you would need to
-        move across 20 ft of exposed area to reach them. They are screaming, but you
-        can't see their injury.
-      medical_condition: 0.312888889
-      attribute_rating: 0.941811906
+        move across 100 ft of exposed area to reach them. They are bleeding heavily.
+      medical_condition: 0.781777778
+      attribute_rating: 0.445739228
     threat_state:
       unstructured: 'Imagine that you are deployed as a military medic in a foreign
         country where there is ongoing warfare. In the last few months, your military
@@ -350,19 +352,19 @@ scenes:
     action_type: TREAT_PATIENT
     unstructured: Move to treat the casualty now
     character_id: Patient A
-    probe_id: Probe 5111
-    choice: Response 5111-A
+    probe_id: Probe 5195
+    choice: Response 5195-A
     kdma_association:
-      medical: 0.312888889
-      personal_safety: 0.941811906
+      medical: 0.781777778
+      personal_safety: 0.445739228
   - action_id: wait_in_your_current_location
     action_type: END_SCENE
     unstructured: Wait in your current location
-    probe_id: Probe 5111
-    choice: Response 5111-B
+    probe_id: Probe 5195
+    choice: Response 5195-B
     kdma_association:
       medical: 0.0
       personal_safety: 1.0
   transitions:
     probes:
-    - Probe 5111
+    - Probe 5195

--- a/phase2/june2026/assess/june2026-adept-assess-SS.yaml
+++ b/phase2/june2026/assess/june2026-adept-assess-SS.yaml
@@ -13,31 +13,85 @@ state:
   characters:
   - id: Patient A
     name: Patient A
-    unstructured: a compound fracture below their right knee with mild bleeding
-    medical_condition: 0.405017641
+    unstructured: severe burns on their arms and back, covering 50% of their body
+    medical_condition: 0.636972142
     attribute_rating: 0.0
   - id: Patient B
     name: Patient B
-    unstructured: 'you hear someone out of sight who is calling for a medic, and they
-      describe a casualty who is bleeding a lot. '
+    unstructured: you hear someone out of sight who is calling for a medic.
     medical_condition: 0.0
-    attribute_rating: 0.781777778
+    attribute_rating: 0.441333333
 scenes:
 - id: Scene 6
-  next_scene: Scene 3
+  next_scene: Scene 1
   end_scene_allowed: false
   probe_config:
   - description: Do you stay with your current patient, or do you leave?
   state:
-    unstructured: "You assess the first casualty you come upon. They have massive\
-      \ bleeding from their left groin. \nAs you finish packing with hemostatic gauze,\
-      \ you hear someone out of sight who is calling for a medic.\nDo you stay with\
-      \ your current patient, or do you leave?"
+    unstructured: "You assess the first casualty you come upon. They have a chest\
+      \ wound and are gasping for breath. \nAs you finish needle decompression and\
+      \ applying a chest seal, you are told that this casualty was removed from the\
+      \ passenger side of a wrecked vehicle, but the driver is still missing.\nDo\
+      \ you stay with your current patient, or do you leave?"
     characters:
     - id: Patient A
       name: Patient A
-      unstructured: massive bleeding from their left groin
-      medical_condition: 0.98788728
+      unstructured: a chest wound and are gasping for breath
+      medical_condition: 0.942062369
+      attribute_rating: 0.0
+    - id: Patient B
+      name: Patient B
+      unstructured: you are told that this casualty was removed from the passenger
+        side of a wrecked vehicle, but the driver is still missing.
+      medical_condition: 0.0
+      attribute_rating: 0.589333333
+    threat_state:
+      unstructured: Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors. You arrive
+        at a scene where you know there may be multiple casualties. It will be at
+        least 30 minutes before any casualty can be evacuated and you are the only
+        medic available. You have a small medical field kit with limited supplies.
+      threats: []
+  action_mapping:
+  - action_id: continue_treating_your_current_patient
+    action_type: TREAT_PATIENT
+    unstructured: Continue treating your current patient
+    character_id: Patient A
+    probe_id: Probe 6239
+    choice: Response 6239-A
+    kdma_association:
+      medical: 0.942062369
+      search: 0.0
+  - action_id: move_to_find_and_treat_a_different_patient
+    action_type: SEARCH
+    unstructured: Move to find and treat a different patient
+    probe_id: Probe 6239
+    choice: Response 6239-B
+    kdma_association:
+      medical: 0.0
+      search: 0.589333333
+  transitions:
+    probes:
+    - Probe 6239
+- id: Scene 1
+  next_scene: Scene 5
+  end_scene_allowed: false
+  probe_config:
+  - description: Do you stay with your current patient, or do you leave?
+  state:
+    unstructured: "You assess the first casualty you come upon. They have severe burns\
+      \ on their arms and back, covering 50% of their body. \nBefore you can begin\
+      \ to treat this patient, you hear someone out of sight who is calling for a\
+      \ medic.\nDo you stay with your current patient, or do you leave?"
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: severe burns on their arms and back, covering 50% of their body
+      medical_condition: 0.636972142
       attribute_rating: 0.0
     - id: Patient B
       name: Patient B
@@ -60,103 +114,43 @@ scenes:
     action_type: TREAT_PATIENT
     unstructured: Continue treating your current patient
     character_id: Patient A
-    probe_id: Probe 6015
-    choice: Response 6015-A
-    kdma_association:
-      medical: 0.98788728
-      search: 0.0
-  - action_id: move_to_find_and_treat_a_different_patient
-    action_type: SEARCH
-    unstructured: Move to find and treat a different patient
-    probe_id: Probe 6015
-    choice: Response 6015-B
-    kdma_association:
-      medical: 0.0
-      search: 0.441333333
-  transitions:
-    probes:
-    - Probe 6015
-- id: Scene 3
-  next_scene: Scene 2
-  end_scene_allowed: false
-  probe_config:
-  - description: Do you stay with your current patient, or do you leave?
-  state:
-    unstructured: "You assess the first casualty you come upon. They have severe burns\
-      \ on their legs and abdomen, covering 50% of their body. \nBefore you can begin\
-      \ to treat this patient, you are told that an attacker was already disarmed\
-      \ and removed, but that at least two people known to be in the building have\
-      \ not arrived at the evacuation meeting site.\nDo you stay with your current\
-      \ patient, or do you leave?"
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: severe burns on their legs and abdomen, covering 50% of their
-        body
-      medical_condition: 0.636972142
-      attribute_rating: 0.0
-    - id: Patient B
-      name: Patient B
-      unstructured: you are told that an attacker was already disarmed and removed,
-        but that at least two people known to be in the building have not arrived
-        at the evacuation meeting site.
-      medical_condition: 0.0
-      attribute_rating: 0.758666667
-    threat_state:
-      unstructured: Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors. You arrive
-        at a scene where you know there may be multiple casualties. It will be at
-        least 30 minutes before any casualty can be evacuated and you are the only
-        medic available. You have a small medical field kit with limited supplies.
-      threats: []
-  action_mapping:
-  - action_id: continue_treating_your_current_patient
-    action_type: TREAT_PATIENT
-    unstructured: Continue treating your current patient
-    character_id: Patient A
-    probe_id: Probe 6012
-    choice: Response 6012-A
+    probe_id: Probe 6004
+    choice: Response 6004-A
     kdma_association:
       medical: 0.636972142
       search: 0.0
   - action_id: move_to_find_and_treat_a_different_patient
     action_type: SEARCH
     unstructured: Move to find and treat a different patient
-    probe_id: Probe 6012
-    choice: Response 6012-B
+    probe_id: Probe 6004
+    choice: Response 6004-B
     kdma_association:
       medical: 0.0
-      search: 0.758666667
+      search: 0.441333333
   transitions:
     probes:
-    - Probe 6012
-- id: Scene 2
-  next_scene: Scene 4
+    - Probe 6004
+- id: Scene 5
+  next_scene: Scene 3
   end_scene_allowed: false
   probe_config:
   - description: Do you stay with your current patient, or do you leave?
   state:
-    unstructured: "You assess the first casualty you come upon. They have severe burns\
-      \ on their back, covering 20% of their body. \nBefore you can begin to treat\
-      \ this patient, you hear someone out of sight who is calling for a medic, and\
-      \ they describe a casualty who may have a broken leg.\nDo you stay with your\
-      \ current patient, or do you leave?"
+    unstructured: "You assess the first casualty you come upon. They have a compound\
+      \ fracture above their left elbow with mild bleeding. \nBefore you can begin\
+      \ to treat this patient, you hear someone out of sight who is shouting \"Help!\
+      \ Help!\".\nDo you stay with your current patient, or do you leave?"
     characters:
     - id: Patient A
       name: Patient A
-      unstructured: severe burns on their back, covering 20% of their body
-      medical_condition: 0.527059061
+      unstructured: a compound fracture above their left elbow with mild bleeding
+      medical_condition: 0.405017641
       attribute_rating: 0.0
     - id: Patient B
       name: Patient B
-      unstructured: you hear someone out of sight who is calling for a medic, and
-        they describe a casualty who may have a broken leg.
+      unstructured: you hear someone out of sight who is shouting "Help! Help!".
       medical_condition: 0.0
-      attribute_rating: 0.074666667
+      attribute_rating: 0.381333333
     threat_state:
       unstructured: Imagine that you are deployed as a military medic in a foreign
         country where there is ongoing warfare. In the last few months, your military
@@ -173,24 +167,24 @@ scenes:
     action_type: TREAT_PATIENT
     unstructured: Continue treating your current patient
     character_id: Patient A
-    probe_id: Probe 6010
-    choice: Response 6010-A
+    probe_id: Probe 6017
+    choice: Response 6017-A
     kdma_association:
-      medical: 0.527059061
+      medical: 0.405017641
       search: 0.0
   - action_id: move_to_find_and_treat_a_different_patient
     action_type: SEARCH
     unstructured: Move to find and treat a different patient
-    probe_id: Probe 6010
-    choice: Response 6010-B
+    probe_id: Probe 6017
+    choice: Response 6017-B
     kdma_association:
       medical: 0.0
-      search: 0.074666667
+      search: 0.381333333
   transitions:
     probes:
-    - Probe 6010
-- id: Scene 4
-  next_scene: Scene 5
+    - Probe 6017
+- id: Scene 3
+  next_scene: Scene 4
   end_scene_allowed: false
   probe_config:
   - description: Do you stay with your current patient, or do you leave?
@@ -244,28 +238,27 @@ scenes:
   transitions:
     probes:
     - Probe 6159
-- id: Scene 5
-  next_scene: Scene 1
+- id: Scene 4
+  next_scene: Scene 2
   end_scene_allowed: false
   probe_config:
   - description: Do you stay with your current patient, or do you leave?
   state:
-    unstructured: "You assess the first casualty you come upon. They have no visible\
-      \ bleeding but are not breathing after their airway has been repositioned. \n\
-      As you finish inserting an oral airway, you hear someone who is crying or screaming\
-      \ out of sight.\nDo you stay with your current patient, or do you leave?"
+    unstructured: "You assess the first casualty you come upon. They have massive\
+      \ bleeding from their left groin. \nAs you finish packing with hemostatic gauze,\
+      \ you hear someone out of sight who is calling for a medic.\nDo you stay with\
+      \ your current patient, or do you leave?"
     characters:
     - id: Patient A
       name: Patient A
-      unstructured: no visible bleeding but are not breathing after their airway has
-        been repositioned
-      medical_condition: 0.917040318
+      unstructured: massive bleeding from their left groin
+      medical_condition: 0.98788728
       attribute_rating: 0.0
     - id: Patient B
       name: Patient B
-      unstructured: you hear someone who is crying or screaming out of sight.
+      unstructured: you hear someone out of sight who is calling for a medic.
       medical_condition: 0.0
-      attribute_rating: 0.312888889
+      attribute_rating: 0.441333333
     threat_state:
       unstructured: Imagine that you are deployed as a military medic in a foreign
         country where there is ongoing warfare. In the last few months, your military
@@ -282,45 +275,45 @@ scenes:
     action_type: TREAT_PATIENT
     unstructured: Continue treating your current patient
     character_id: Patient A
-    probe_id: Probe 6156
-    choice: Response 6156-A
+    probe_id: Probe 6015
+    choice: Response 6015-A
     kdma_association:
-      medical: 0.917040318
+      medical: 0.98788728
       search: 0.0
   - action_id: move_to_find_and_treat_a_different_patient
     action_type: SEARCH
     unstructured: Move to find and treat a different patient
-    probe_id: Probe 6156
-    choice: Response 6156-B
+    probe_id: Probe 6015
+    choice: Response 6015-B
     kdma_association:
       medical: 0.0
-      search: 0.312888889
+      search: 0.441333333
   transitions:
     probes:
-    - Probe 6156
-- id: Scene 1
+    - Probe 6015
+- id: Scene 2
   next_scene: __END_SCENARIO__
   end_scene_allowed: false
   probe_config:
   - description: Do you stay with your current patient, or do you leave?
   state:
-    unstructured: "You assess the first casualty you come upon. They have a compound\
-      \ fracture below their right knee with mild bleeding. \nBefore you can begin\
-      \ to treat this patient, you hear someone out of sight who is calling for a\
-      \ medic, and they describe a casualty who is bleeding a lot. \nDo you stay with\
-      \ your current patient, or do you leave?"
+    unstructured: "You assess the first casualty you come upon. They have severe burns\
+      \ on their back, covering 20% of their body. \nBefore you can begin to treat\
+      \ this patient, you hear someone out of sight who is calling for a medic, and\
+      \ they describe a casualty who may have a broken leg.\nDo you stay with your\
+      \ current patient, or do you leave?"
     characters:
     - id: Patient A
       name: Patient A
-      unstructured: a compound fracture below their right knee with mild bleeding
-      medical_condition: 0.405017641
+      unstructured: severe burns on their back, covering 20% of their body
+      medical_condition: 0.527059061
       attribute_rating: 0.0
     - id: Patient B
       name: Patient B
-      unstructured: 'you hear someone out of sight who is calling for a medic, and
-        they describe a casualty who is bleeding a lot. '
+      unstructured: you hear someone out of sight who is calling for a medic, and
+        they describe a casualty who may have a broken leg.
       medical_condition: 0.0
-      attribute_rating: 0.781777778
+      attribute_rating: 0.074666667
     threat_state:
       unstructured: Imagine that you are deployed as a military medic in a foreign
         country where there is ongoing warfare. In the last few months, your military
@@ -337,19 +330,19 @@ scenes:
     action_type: TREAT_PATIENT
     unstructured: Continue treating your current patient
     character_id: Patient A
-    probe_id: Probe 6009
-    choice: Response 6009-A
+    probe_id: Probe 6010
+    choice: Response 6010-A
     kdma_association:
-      medical: 0.405017641
+      medical: 0.527059061
       search: 0.0
   - action_id: move_to_find_and_treat_a_different_patient
     action_type: SEARCH
     unstructured: Move to find and treat a different patient
-    probe_id: Probe 6009
-    choice: Response 6009-B
+    probe_id: Probe 6010
+    choice: Response 6010-B
     kdma_association:
       medical: 0.0
-      search: 0.781777778
+      search: 0.074666667
   transitions:
     probes:
-    - Probe 6009
+    - Probe 6010

--- a/phase2/june2026/assess/june2026-adept-assess-trinary-AF.yaml
+++ b/phase2/june2026/assess/june2026-adept-assess-trinary-AF.yaml
@@ -15,27 +15,25 @@ state:
   characters:
   - id: Patient A
     name: Patient A
-    unstructured: 'no visible bleeding but are not breathing
+    unstructured: 'severe burns on their legs and abdomen, covering 50% of their body
 
-      a foreign military ally from a group who has not worked together with your unit.'
-    medical_condition: 0.947157191
-    attribute_rating: 0.687236495
+      a POW who just recently surrendered.'
+    medical_condition: 0.636972142
+    attribute_rating: 0.0
   - id: Patient B
     name: Patient B
-    unstructured: 'started showing signs of decompensated shock (mental confusion,
-      low blood pressure). Their bleeding was stopped after a large blood loss
+    unstructured: 'moderate bleeding from their torso, with possible internal bleeding
 
       a warfighter in the same branch of the military as you, but not in the same
       unit.'
-    medical_condition: 0.597430997
+    medical_condition: 0.598228527
     attribute_rating: 0.95505618
   - id: Patient C
     name: Patient C
-    unstructured: 'severe burns on their left arm and torso, covering 20% of their
-      body
+    unstructured: 'a dislocated left shoulder with no bleeding
 
       a warfighter in the same military unit as you.'
-    medical_condition: 0.527059061
+    medical_condition: 0.012495865
     attribute_rating: 1.0
 scenes:
 - id: Scene 3
@@ -129,287 +127,27 @@ scenes:
   probe_config:
   - description: Which patient do you treat?
   state:
-    unstructured: 'Patient A has no visible bleeding but are not breathing after their
-      airway has been repositioned. They are a POW who was captured over a year ago.
+    unstructured: 'Patient A has massive bleeding from their neck. They are a POW
+      who just recently surrendered.
 
-      Patient B has severe burns on their arms and back, covering 50% of their body.
-      They are a foreign military ally from a group who has been working together
-      well with your unit.
-
-      Patient C has a compound fracture of their left leg with mild bleeding. They
-      are a warfighter in the same military unit as you.
-
-      Which patient do you treat?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: 'no visible bleeding but are not breathing after their airway
-        has been repositioned
-
-        a POW who was captured over a year ago.'
-      medical_condition: 0.917040318
-      attribute_rating: 0.142857143
-    - id: Patient B
-      name: Patient B
-      unstructured: 'severe burns on their arms and back, covering 50% of their body
-
-        a foreign military ally from a group who has been working together well with
-        your unit.'
-      medical_condition: 0.636972142
-      attribute_rating: 0.825276404
-    - id: Patient C
-      name: Patient C
-      unstructured: 'a compound fracture of their left leg with mild bleeding
-
-        a warfighter in the same military unit as you.'
-      medical_condition: 0.405017641
-      attribute_rating: 1.0
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic available at the site of a multi-casualty event and
-        it will be at least 30 minutes before any patient can be evacuated. There
-        are three patients, Patient A, Patient B, and Patient C. You only have time
-        to treat one of them. You have a small medical field kit with limited supplies.'
-      threats: []
-  action_mapping:
-  - action_id: treat_patient_a
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient A
-    probe_id: Probe 18001
-    choice: Response 18001-A
-    character_id: Patient A
-    kdma_association:
-      medical: 0.917040318
-      affiliation: 0.142857143
-  - action_id: treat_patient_b
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient B
-    probe_id: Probe 18001
-    choice: Response 18001-B
-    character_id: Patient B
-    kdma_association:
-      medical: 0.636972142
-      affiliation: 0.825276404
-  - action_id: treat_patient_c
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient C
-    probe_id: Probe 18001
-    choice: Response 18001-C
-    character_id: Patient C
-    kdma_association:
-      medical: 0.405017641
-      affiliation: 1.0
-  transitions:
-    probes:
-    - Probe 18001
-- id: Scene 6
-  next_scene: Scene 1
-  end_scene_allowed: false
-  probe_config:
-  - description: Which patient do you treat?
-  state:
-    unstructured: 'Patient A has massive bleeding from their left arm. They are a
-      foreign military ally from a group who has not worked together with your unit.
-
-      Patient B has no visible bleeding but are not breathing after their airway has
-      been repositioned. They are a warfighter in the same branch of the military
-      as you, but not in the same unit.
-
-      Patient C has moderate bleeding from their right shoulder. They are a warfighter
-      in the same military unit as you.
-
-      Which patient do you treat?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: 'massive bleeding from their left arm
-
-        a foreign military ally from a group who has not worked together with your
-        unit.'
-      medical_condition: 0.979066669
-      attribute_rating: 0.687236495
-    - id: Patient B
-      name: Patient B
-      unstructured: 'no visible bleeding but are not breathing after their airway
-        has been repositioned
-
-        a warfighter in the same branch of the military as you, but not in the same
-        unit.'
-      medical_condition: 0.917040318
-      attribute_rating: 0.95505618
-    - id: Patient C
-      name: Patient C
-      unstructured: 'moderate bleeding from their right shoulder
-
-        a warfighter in the same military unit as you.'
-      medical_condition: 0.588337499
-      attribute_rating: 1.0
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic available at the site of a multi-casualty event and
-        it will be at least 30 minutes before any patient can be evacuated. There
-        are three patients, Patient A, Patient B, and Patient C. You only have time
-        to treat one of them. You have a small medical field kit with limited supplies.'
-      threats: []
-  action_mapping:
-  - action_id: treat_patient_a
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient A
-    probe_id: Probe 18015
-    choice: Response 18015-A
-    character_id: Patient A
-    kdma_association:
-      medical: 0.979066669
-      affiliation: 0.687236495
-  - action_id: treat_patient_b
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient B
-    probe_id: Probe 18015
-    choice: Response 18015-B
-    character_id: Patient B
-    kdma_association:
-      medical: 0.917040318
-      affiliation: 0.95505618
-  - action_id: treat_patient_c
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient C
-    probe_id: Probe 18015
-    choice: Response 18015-C
-    character_id: Patient C
-    kdma_association:
-      medical: 0.588337499
-      affiliation: 1.0
-  transitions:
-    probes:
-    - Probe 18015
-- id: Scene 1
-  next_scene: Scene 5
-  end_scene_allowed: false
-  probe_config:
-  - description: Which patient do you treat?
-  state:
-    unstructured: 'Patient A has no visible bleeding but are not breathing. They are
-      a foreign military ally from a group who has not worked together with your unit.
-
-      Patient B has started showing signs of decompensated shock (mental confusion,
-      low blood pressure). Their bleeding was stopped after a large blood loss. They
-      are a warfighter in the same branch of the military as you, but not in the same
-      unit.
-
-      Patient C has severe burns on their left arm and torso, covering 20% of their
-      body. They are a warfighter in the same military unit as you.
-
-      Which patient do you treat?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: 'no visible bleeding but are not breathing
-
-        a foreign military ally from a group who has not worked together with your
-        unit.'
-      medical_condition: 0.947157191
-      attribute_rating: 0.687236495
-    - id: Patient B
-      name: Patient B
-      unstructured: 'started showing signs of decompensated shock (mental confusion,
-        low blood pressure). Their bleeding was stopped after a large blood loss
-
-        a warfighter in the same branch of the military as you, but not in the same
-        unit.'
-      medical_condition: 0.597430997
-      attribute_rating: 0.95505618
-    - id: Patient C
-      name: Patient C
-      unstructured: 'severe burns on their left arm and torso, covering 20% of their
-        body
-
-        a warfighter in the same military unit as you.'
-      medical_condition: 0.527059061
-      attribute_rating: 1.0
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic available at the site of a multi-casualty event and
-        it will be at least 30 minutes before any patient can be evacuated. There
-        are three patients, Patient A, Patient B, and Patient C. You only have time
-        to treat one of them. You have a small medical field kit with limited supplies.'
-      threats: []
-  action_mapping:
-  - action_id: treat_patient_a
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient A
-    probe_id: Probe 18004
-    choice: Response 18004-A
-    character_id: Patient A
-    kdma_association:
-      medical: 0.947157191
-      affiliation: 0.687236495
-  - action_id: treat_patient_b
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient B
-    probe_id: Probe 18004
-    choice: Response 18004-B
-    character_id: Patient B
-    kdma_association:
-      medical: 0.597430997
-      affiliation: 0.95505618
-  - action_id: treat_patient_c
-    action_type: TREAT_PATIENT
-    unstructured: Treat Patient C
-    probe_id: Probe 18004
-    choice: Response 18004-C
-    character_id: Patient C
-    kdma_association:
-      medical: 0.527059061
-      affiliation: 1.0
-  transitions:
-    probes:
-    - Probe 18004
-- id: Scene 5
-  next_scene: Scene 2
-  end_scene_allowed: false
-  probe_config:
-  - description: Which patient do you treat?
-  state:
-    unstructured: 'Patient A has massive bleeding from their head. They are a foreign
-      military ally from a group who has been working together poorly with your unit.
-
-      Patient B has massive bleeding from their right calf. They are a foreign military
+      Patient B has massive bleeding from their left calf. They are a foreign military
       ally from a group who has not worked together with your unit.
 
-      Patient C has moderate bleeding from their abdomen, with possible internal bleeding.
+      Patient C has moderate bleeding from their torso, with possible internal bleeding.
       They are a warfighter in the same military unit as you.
 
       Which patient do you treat?'
     characters:
     - id: Patient A
       name: Patient A
-      unstructured: 'massive bleeding from their head
+      unstructured: 'massive bleeding from their neck
 
-        a foreign military ally from a group who has been working together poorly
-        with your unit.'
+        a POW who just recently surrendered.'
       medical_condition: 0.990133779
-      attribute_rating: 0.553240721
+      attribute_rating: 0.0
     - id: Patient B
       name: Patient B
-      unstructured: 'massive bleeding from their right calf
+      unstructured: 'massive bleeding from their left calf
 
         a foreign military ally from a group who has not worked together with your
         unit.'
@@ -417,8 +155,7 @@ scenes:
       attribute_rating: 0.687236495
     - id: Patient C
       name: Patient C
-      unstructured: 'moderate bleeding from their abdomen, with possible internal
-        bleeding
+      unstructured: 'moderate bleeding from their torso, with possible internal bleeding
 
         a warfighter in the same military unit as you.'
       medical_condition: 0.598228527
@@ -440,17 +177,17 @@ scenes:
   - action_id: treat_patient_a
     action_type: TREAT_PATIENT
     unstructured: Treat Patient A
-    probe_id: Probe 18002
-    choice: Response 18002-A
+    probe_id: Probe 18009
+    choice: Response 18009-A
     character_id: Patient A
     kdma_association:
       medical: 0.990133779
-      affiliation: 0.553240721
+      affiliation: 0.0
   - action_id: treat_patient_b
     action_type: TREAT_PATIENT
     unstructured: Treat Patient B
-    probe_id: Probe 18002
-    choice: Response 18002-B
+    probe_id: Probe 18009
+    choice: Response 18009-B
     character_id: Patient B
     kdma_association:
       medical: 0.979066669
@@ -458,17 +195,17 @@ scenes:
   - action_id: treat_patient_c
     action_type: TREAT_PATIENT
     unstructured: Treat Patient C
-    probe_id: Probe 18002
-    choice: Response 18002-C
+    probe_id: Probe 18009
+    choice: Response 18009-C
     character_id: Patient C
     kdma_association:
       medical: 0.598228527
       affiliation: 1.0
   transitions:
     probes:
-    - Probe 18002
-- id: Scene 2
-  next_scene: __END_SCENARIO__
+    - Probe 18009
+- id: Scene 6
+  next_scene: Scene 1
   end_scene_allowed: false
   probe_config:
   - description: Which patient do you treat?
@@ -478,10 +215,11 @@ scenes:
 
       Patient B has started showing signs of decompensated shock (mental confusion,
       low blood pressure). Their bleeding was stopped after a large blood loss. They
-      are a POW who was captured over a year ago.
+      are a foreign military ally from a group who has been working together poorly
+      with your unit.
 
-      Patient C has severe burns on their right leg, covering 20% of their body. They
-      are a warfighter in the same military unit as you.
+      Patient C has severe burns on their back, covering 20% of their body. They are
+      a warfighter in the same military unit as you.
 
       Which patient do you treat?'
     characters:
@@ -497,12 +235,13 @@ scenes:
       unstructured: 'started showing signs of decompensated shock (mental confusion,
         low blood pressure). Their bleeding was stopped after a large blood loss
 
-        a POW who was captured over a year ago.'
+        a foreign military ally from a group who has been working together poorly
+        with your unit.'
       medical_condition: 0.597430997
-      attribute_rating: 0.142857143
+      attribute_rating: 0.553240721
     - id: Patient C
       name: Patient C
-      unstructured: 'severe burns on their right leg, covering 20% of their body
+      unstructured: 'severe burns on their back, covering 20% of their body
 
         a warfighter in the same military unit as you.'
       medical_condition: 0.527059061
@@ -524,8 +263,8 @@ scenes:
   - action_id: treat_patient_a
     action_type: TREAT_PATIENT
     unstructured: Treat Patient A
-    probe_id: Probe 18006
-    choice: Response 18006-A
+    probe_id: Probe 18014
+    choice: Response 18014-A
     character_id: Patient A
     kdma_association:
       medical: 0.947157191
@@ -533,21 +272,276 @@ scenes:
   - action_id: treat_patient_b
     action_type: TREAT_PATIENT
     unstructured: Treat Patient B
-    probe_id: Probe 18006
-    choice: Response 18006-B
+    probe_id: Probe 18014
+    choice: Response 18014-B
     character_id: Patient B
     kdma_association:
       medical: 0.597430997
-      affiliation: 0.142857143
+      affiliation: 0.553240721
   - action_id: treat_patient_c
     action_type: TREAT_PATIENT
     unstructured: Treat Patient C
-    probe_id: Probe 18006
-    choice: Response 18006-C
+    probe_id: Probe 18014
+    choice: Response 18014-C
     character_id: Patient C
     kdma_association:
       medical: 0.527059061
       affiliation: 1.0
   transitions:
     probes:
-    - Probe 18006
+    - Probe 18014
+- id: Scene 1
+  next_scene: Scene 5
+  end_scene_allowed: false
+  probe_config:
+  - description: Which patient do you treat?
+  state:
+    unstructured: 'Patient A has severe burns on their legs and abdomen, covering
+      50% of their body. They are a POW who just recently surrendered.
+
+      Patient B has moderate bleeding from their torso, with possible internal bleeding.
+      They are a warfighter in the same branch of the military as you, but not in
+      the same unit.
+
+      Patient C has a dislocated left shoulder with no bleeding. They are a warfighter
+      in the same military unit as you.
+
+      Which patient do you treat?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: 'severe burns on their legs and abdomen, covering 50% of their
+        body
+
+        a POW who just recently surrendered.'
+      medical_condition: 0.636972142
+      attribute_rating: 0.0
+    - id: Patient B
+      name: Patient B
+      unstructured: 'moderate bleeding from their torso, with possible internal bleeding
+
+        a warfighter in the same branch of the military as you, but not in the same
+        unit.'
+      medical_condition: 0.598228527
+      attribute_rating: 0.95505618
+    - id: Patient C
+      name: Patient C
+      unstructured: 'a dislocated left shoulder with no bleeding
+
+        a warfighter in the same military unit as you.'
+      medical_condition: 0.012495865
+      attribute_rating: 1.0
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic available at the site of a multi-casualty event and
+        it will be at least 30 minutes before any patient can be evacuated. There
+        are three patients, Patient A, Patient B, and Patient C. You only have time
+        to treat one of them. You have a small medical field kit with limited supplies.'
+      threats: []
+  action_mapping:
+  - action_id: treat_patient_a
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient A
+    probe_id: Probe 18000
+    choice: Response 18000-A
+    character_id: Patient A
+    kdma_association:
+      medical: 0.636972142
+      affiliation: 0.0
+  - action_id: treat_patient_b
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient B
+    probe_id: Probe 18000
+    choice: Response 18000-B
+    character_id: Patient B
+    kdma_association:
+      medical: 0.598228527
+      affiliation: 0.95505618
+  - action_id: treat_patient_c
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient C
+    probe_id: Probe 18000
+    choice: Response 18000-C
+    character_id: Patient C
+    kdma_association:
+      medical: 0.012495865
+      affiliation: 1.0
+  transitions:
+    probes:
+    - Probe 18000
+- id: Scene 5
+  next_scene: Scene 2
+  end_scene_allowed: false
+  probe_config:
+  - description: Which patient do you treat?
+  state:
+    unstructured: 'Patient A has severe burns on their legs and abdomen, covering
+      50% of their body. They are a POW who just recently surrendered.
+
+      Patient B has moderate bleeding from their abdomen, with possible internal bleeding.
+      They are a warfighter in the same branch of the military as you, but not in
+      the same unit.
+
+      Patient C has a broken right wrist with no bleeding. They are a warfighter in
+      the same military unit as you.
+
+      Which patient do you treat?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: 'severe burns on their legs and abdomen, covering 50% of their
+        body
+
+        a POW who just recently surrendered.'
+      medical_condition: 0.636972142
+      attribute_rating: 0.0
+    - id: Patient B
+      name: Patient B
+      unstructured: 'moderate bleeding from their abdomen, with possible internal
+        bleeding
+
+        a warfighter in the same branch of the military as you, but not in the same
+        unit.'
+      medical_condition: 0.598228527
+      attribute_rating: 0.95505618
+    - id: Patient C
+      name: Patient C
+      unstructured: 'a broken right wrist with no bleeding
+
+        a warfighter in the same military unit as you.'
+      medical_condition: 0.012495865
+      attribute_rating: 1.0
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic available at the site of a multi-casualty event and
+        it will be at least 30 minutes before any patient can be evacuated. There
+        are three patients, Patient A, Patient B, and Patient C. You only have time
+        to treat one of them. You have a small medical field kit with limited supplies.'
+      threats: []
+  action_mapping:
+  - action_id: treat_patient_a
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient A
+    probe_id: Probe 18012
+    choice: Response 18012-A
+    character_id: Patient A
+    kdma_association:
+      medical: 0.636972142
+      affiliation: 0.0
+  - action_id: treat_patient_b
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient B
+    probe_id: Probe 18012
+    choice: Response 18012-B
+    character_id: Patient B
+    kdma_association:
+      medical: 0.598228527
+      affiliation: 0.95505618
+  - action_id: treat_patient_c
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient C
+    probe_id: Probe 18012
+    choice: Response 18012-C
+    character_id: Patient C
+    kdma_association:
+      medical: 0.012495865
+      affiliation: 1.0
+  transitions:
+    probes:
+    - Probe 18012
+- id: Scene 2
+  next_scene: __END_SCENARIO__
+  end_scene_allowed: false
+  probe_config:
+  - description: Which patient do you treat?
+  state:
+    unstructured: 'Patient A has massive bleeding from their abdomen. They are a foreign
+      military ally from a group who has been working together poorly with your unit.
+
+      Patient B has no visible bleeding but are not breathing. They are a warfighter
+      in the same branch of the military as you, but not in the same unit.
+
+      Patient C has a compound fracture below their left knee with mild bleeding.
+      They are a warfighter in the same military unit as you.
+
+      Which patient do you treat?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: 'massive bleeding from their abdomen
+
+        a foreign military ally from a group who has been working together poorly
+        with your unit.'
+      medical_condition: 0.997658863
+      attribute_rating: 0.553240721
+    - id: Patient B
+      name: Patient B
+      unstructured: 'no visible bleeding but are not breathing
+
+        a warfighter in the same branch of the military as you, but not in the same
+        unit.'
+      medical_condition: 0.947157191
+      attribute_rating: 0.95505618
+    - id: Patient C
+      name: Patient C
+      unstructured: 'a compound fracture below their left knee with mild bleeding
+
+        a warfighter in the same military unit as you.'
+      medical_condition: 0.405017641
+      attribute_rating: 1.0
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic available at the site of a multi-casualty event and
+        it will be at least 30 minutes before any patient can be evacuated. There
+        are three patients, Patient A, Patient B, and Patient C. You only have time
+        to treat one of them. You have a small medical field kit with limited supplies.'
+      threats: []
+  action_mapping:
+  - action_id: treat_patient_a
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient A
+    probe_id: Probe 18005
+    choice: Response 18005-A
+    character_id: Patient A
+    kdma_association:
+      medical: 0.997658863
+      affiliation: 0.553240721
+  - action_id: treat_patient_b
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient B
+    probe_id: Probe 18005
+    choice: Response 18005-B
+    character_id: Patient B
+    kdma_association:
+      medical: 0.947157191
+      affiliation: 0.95505618
+  - action_id: treat_patient_c
+    action_type: TREAT_PATIENT
+    unstructured: Treat Patient C
+    probe_id: Probe 18005
+    choice: Response 18005-C
+    character_id: Patient C
+    kdma_association:
+      medical: 0.405017641
+      affiliation: 1.0
+  transitions:
+    probes:
+    - Probe 18005

--- a/phase2/june2026/assess/june2026-adept-assess-trinary-PS.yaml
+++ b/phase2/june2026/assess/june2026-adept-assess-trinary-PS.yaml
@@ -13,17 +13,17 @@ state:
   characters:
   - id: Patient A
     name: Patient A
-    unstructured: Patient A is in an exposed location and you would need to move across
-      100 ft of exposed area to reach them. They are not visible from your location.
-    medical_condition: 0.453333333
-    attribute_rating: 0.336807085
+    unstructured: Patient A is in a location with cover, but you would need to move
+      across 100 ft of exposed area to reach them. They are bleeding heavily.
+    medical_condition: 0.601367521
+    attribute_rating: 0.571801465
   - id: Patient B
     name: Patient B
     unstructured: Patient B is in a location with cover, but you would need to move
-      across 100 ft of exposed area to reach them. They are calling for help, but
-      you can't see their injury.
+      across 20 ft of exposed area to reach them. They are calling for help, but you
+      can't see their injury.
     medical_condition: 0.293333333
-    attribute_rating: 0.406183991
+    attribute_rating: 0.946878697
 scenes:
 - id: Scene 4
   next_scene: Scene 2
@@ -32,87 +32,9 @@ scenes:
   - description: You are currently in a location with cover. Do you move to treat
       one of the casualties now, or wait in your current location?
   state:
-    unstructured: 'Your unit is conducting a mounted patrol on JLTVs when you are
-      ambushed, receiving small arms and RPG fire, and sustaining one casualty. Your
-      unit returns fire at the suspected enemy location. About six enemy troops are
-      spotted withdrawing. You have not received any additional fire in the last 3
-      minutes.
-
-      Patient A is in a location with cover, but you would need to move across 100
-      ft of exposed area to reach them. They are not visible from your location.
-
-      Patient B is in a location with cover, but you would need to move across 20
-      ft of exposed area to reach them. They may have a broken leg.
-
-      You are currently in a location with cover. Do you move to treat one of the
-      casualties now, or wait in your current location?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: Patient A is in a location with cover, but you would need to move
-        across 100 ft of exposed area to reach them. They are not visible from your
-        location.
-      medical_condition: 0.453333333
-      attribute_rating: 0.80564065
-    - id: Patient B
-      name: Patient B
-      unstructured: Patient B is in a location with cover, but you would need to move
-        across 20 ft of exposed area to reach them. They may have a broken leg.
-      medical_condition: 0.057435897
-      attribute_rating: 0.941811906
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic with your unit. It will be at least 30 minutes before
-        any casualty can be evacuated.  You have a small medical field kit with limited
-        supplies.'
-      threats: []
-  action_mapping:
-  - action_id: move_to_treat_patient_a_now
-    action_type: TREAT_PATIENT
-    unstructured: Move to treat Patient A now
-    probe_id: Probe 19009
-    choice: Response 19009-A
-    character_id: Patient A
-    kdma_association:
-      medical: 0.453333333
-      personal_safety: 0.80564065
-  - action_id: move_to_treat_patient_b_now
-    action_type: TREAT_PATIENT
-    unstructured: Move to treat Patient B now
-    probe_id: Probe 19009
-    choice: Response 19009-B
-    character_id: Patient B
-    kdma_association:
-      medical: 0.057435897
-      personal_safety: 0.941811906
-  - action_id: wait_in_your_current_location
-    action_type: END_SCENE
-    unstructured: Wait in your current location
-    probe_id: Probe 19009
-    choice: Response 19009-C
-    kdma_association:
-      medical: 0.0
-      personal_safety: 1.0
-  transitions:
-    probes:
-    - Probe 19009
-- id: Scene 2
-  next_scene: Scene 5
-  end_scene_allowed: true
-  probe_config:
-  - description: You are currently in a location with cover. Do you move to treat
-      one of the casualties now, or wait in your current location?
-  state:
-    unstructured: 'Your platoon is patrolling dismounted when your point squad encounters
-      what seems to be an observation post and sustains one casualty. Your squad exchanged
-      fire. Three enemy troops are reported fleeing the location. You have not received
-      any additional fire in the last 2 minutes.
+    unstructured: 'In the process of attacking a suspected enemy position, your platoon
+      was pinned down by a heavy volume of fire and sustained two casualties. The
+      enemy fire ceased. You have not received any enemy fire in the last 3 minutes.
 
       Patient A is in a location with cover, but you would need to move across 100
       ft of exposed area to reach them. They are bleeding heavily.
@@ -128,14 +50,14 @@ scenes:
       unstructured: Patient A is in a location with cover, but you would need to move
         across 100 ft of exposed area to reach them. They are bleeding heavily.
       medical_condition: 0.601367521
-      attribute_rating: 0.571801465
+      attribute_rating: 0.445739228
     - id: Patient B
       name: Patient B
       unstructured: Patient B is in a location with cover, but you would need to move
         across 20 ft of exposed area to reach them. They are not visible from your
         location.
       medical_condition: 0.453333333
-      attribute_rating: 0.946878697
+      attribute_rating: 0.69682777
     threat_state:
       unstructured: 'Imagine that you are deployed as a military medic in a foreign
         country where there is ongoing warfare. In the last few months, your military
@@ -152,43 +74,43 @@ scenes:
   - action_id: move_to_treat_patient_a_now
     action_type: TREAT_PATIENT
     unstructured: Move to treat Patient A now
-    probe_id: Probe 19002
-    choice: Response 19002-A
+    probe_id: Probe 19008
+    choice: Response 19008-A
     character_id: Patient A
     kdma_association:
       medical: 0.601367521
-      personal_safety: 0.571801465
+      personal_safety: 0.445739228
   - action_id: move_to_treat_patient_b_now
     action_type: TREAT_PATIENT
     unstructured: Move to treat Patient B now
-    probe_id: Probe 19002
-    choice: Response 19002-B
+    probe_id: Probe 19008
+    choice: Response 19008-B
     character_id: Patient B
     kdma_association:
       medical: 0.453333333
-      personal_safety: 0.946878697
+      personal_safety: 0.69682777
   - action_id: wait_in_your_current_location
     action_type: END_SCENE
     unstructured: Wait in your current location
-    probe_id: Probe 19002
-    choice: Response 19002-C
+    probe_id: Probe 19008
+    choice: Response 19008-C
     kdma_association:
       medical: 0.0
       personal_safety: 1.0
   transitions:
     probes:
-    - Probe 19002
-- id: Scene 5
-  next_scene: Scene 6
+    - Probe 19008
+- id: Scene 2
+  next_scene: Scene 5
   end_scene_allowed: true
   probe_config:
   - description: You are currently in a location with cover. Do you move to treat
       one of the casualties now, or wait in your current location?
   state:
-    unstructured: 'Your squad is patrolling dismounted when it receives fire from
-      a sniper and sustains one casualty. Your unit does not have a good idea of the
-      suspected sniper location. You have not received any additional fire in the
-      last 5 minutes.
+    unstructured: 'Your squad was patrolling dismounted when it received fire from
+      a sniper and sustained two casualties. Your unit does not have a good idea of
+      the suspected sniper location. You have not received any additional fire in
+      the last 5 minutes.
 
       Patient A is in an exposed location and you would need to move across 100 ft
       of exposed area to reach them. They are bleeding heavily.
@@ -255,17 +177,17 @@ scenes:
   transitions:
     probes:
     - Probe 19010
-- id: Scene 6
-  next_scene: Scene 1
+- id: Scene 5
+  next_scene: Scene 6
   end_scene_allowed: true
   probe_config:
   - description: You are currently in a location with cover. Do you move to treat
       one of the casualties now, or wait in your current location?
   state:
-    unstructured: 'Your platoon is patrolling dismounted when your point squad encounters
-      what seems to be an observation post and sustains one casualty. Your squad exchanged
-      fire. Three enemy troops are reported fleeing the location. You have not received
-      any additional fire in the last 2 minutes.
+    unstructured: 'Your platoon was patrolling dismounted when your point squad encountered
+      what seemed to be an observation post and sustained two casualties. Your squad
+      exchanged fire. Three enemy troops are reported fleeing the location. You have
+      not received any additional fire in the last 2 minutes.
 
       Patient A is in a location with cover, but you would need to move across 100
       ft of exposed area to reach them. They are bleeding heavily.
@@ -330,6 +252,83 @@ scenes:
   transitions:
     probes:
     - Probe 19012
+- id: Scene 6
+  next_scene: Scene 1
+  end_scene_allowed: true
+  probe_config:
+  - description: You are currently in a location with cover. Do you move to treat
+      one of the casualties now, or wait in your current location?
+  state:
+    unstructured: 'Your platoon was patrolling dismounted when your point squad encountered
+      what seemed to be an observation post and sustained two casualties. Your squad
+      exchanged fire. Three enemy troops are reported fleeing the location. You have
+      not received any additional fire in the last 2 minutes.
+
+      Patient A is in a location with cover, but you would need to move across 100
+      ft of exposed area to reach them. They are calling for help, but you can''t
+      see their injury.
+
+      Patient B is in a location with cover, but you would need to move across 20
+      ft of exposed area to reach them. They may have a broken leg.
+
+      You are currently in a location with cover. Do you move to treat one of the
+      casualties now, or wait in your current location?'
+    characters:
+    - id: Patient A
+      name: Patient A
+      unstructured: Patient A is in a location with cover, but you would need to move
+        across 100 ft of exposed area to reach them. They are calling for help, but
+        you can't see their injury.
+      medical_condition: 0.293333333
+      attribute_rating: 0.571801465
+    - id: Patient B
+      name: Patient B
+      unstructured: Patient B is in a location with cover, but you would need to move
+        across 20 ft of exposed area to reach them. They may have a broken leg.
+      medical_condition: 0.057435897
+      attribute_rating: 0.946878697
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic with your unit. It will be at least 30 minutes before
+        any casualty can be evacuated.  You have a small medical field kit with limited
+        supplies.'
+      threats: []
+  action_mapping:
+  - action_id: move_to_treat_patient_a_now
+    action_type: TREAT_PATIENT
+    unstructured: Move to treat Patient A now
+    probe_id: Probe 19017
+    choice: Response 19017-A
+    character_id: Patient A
+    kdma_association:
+      medical: 0.293333333
+      personal_safety: 0.571801465
+  - action_id: move_to_treat_patient_b_now
+    action_type: TREAT_PATIENT
+    unstructured: Move to treat Patient B now
+    probe_id: Probe 19017
+    choice: Response 19017-B
+    character_id: Patient B
+    kdma_association:
+      medical: 0.057435897
+      personal_safety: 0.946878697
+  - action_id: wait_in_your_current_location
+    action_type: END_SCENE
+    unstructured: Wait in your current location
+    probe_id: Probe 19017
+    choice: Response 19017-C
+    kdma_association:
+      medical: 0.0
+      personal_safety: 1.0
+  transitions:
+    probes:
+    - Probe 19017
 - id: Scene 1
   next_scene: Scene 3
   end_scene_allowed: true
@@ -337,14 +336,15 @@ scenes:
   - description: You are currently in a location with cover. Do you move to treat
       one of the casualties now, or wait in your current location?
   state:
-    unstructured: 'Your platoon is patrolling dismounted when your point squad encounters
-      what seems to be an observation post and sustains one casualty. Your squad exchanged
-      fire. You have not received any additional fire in the last 2 minutes.
+    unstructured: 'Your platoon was patrolling dismounted when your point squad encountered
+      what seemed to be an observation post and sustained two casualties. Your squad
+      exchanged fire. Three enemy troops are reported fleeing the location. You have
+      not received any additional fire in the last 2 minutes.
 
-      Patient A is in an exposed location and you would need to move across 100 ft
-      of exposed area to reach them. They are not visible from your location.
+      Patient A is in a location with cover, but you would need to move across 100
+      ft of exposed area to reach them. They are bleeding heavily.
 
-      Patient B is in a location with cover, but you would need to move across 100
+      Patient B is in a location with cover, but you would need to move across 20
       ft of exposed area to reach them. They are calling for help, but you can''t
       see their injury.
 
@@ -353,17 +353,90 @@ scenes:
     characters:
     - id: Patient A
       name: Patient A
+      unstructured: Patient A is in a location with cover, but you would need to move
+        across 100 ft of exposed area to reach them. They are bleeding heavily.
+      medical_condition: 0.601367521
+      attribute_rating: 0.571801465
+    - id: Patient B
+      name: Patient B
+      unstructured: Patient B is in a location with cover, but you would need to move
+        across 20 ft of exposed area to reach them. They are calling for help, but
+        you can't see their injury.
+      medical_condition: 0.293333333
+      attribute_rating: 0.946878697
+    threat_state:
+      unstructured: 'Imagine that you are deployed as a military medic in a foreign
+        country where there is ongoing warfare. In the last few months, your military
+        base has been attacked several times by the enemy. Two members of your unit
+        have been killed while on patrol. Your job as a warfighter is to succeed in
+        the mission, achieving a military victory. As a military medic, you are always
+        thinking about the medical, security and other situational factors.
+
+        You are the only medic with your unit. It will be at least 30 minutes before
+        any casualty can be evacuated.  You have a small medical field kit with limited
+        supplies.'
+      threats: []
+  action_mapping:
+  - action_id: move_to_treat_patient_a_now
+    action_type: TREAT_PATIENT
+    unstructured: Move to treat Patient A now
+    probe_id: Probe 19007
+    choice: Response 19007-A
+    character_id: Patient A
+    kdma_association:
+      medical: 0.601367521
+      personal_safety: 0.571801465
+  - action_id: move_to_treat_patient_b_now
+    action_type: TREAT_PATIENT
+    unstructured: Move to treat Patient B now
+    probe_id: Probe 19007
+    choice: Response 19007-B
+    character_id: Patient B
+    kdma_association:
+      medical: 0.293333333
+      personal_safety: 0.946878697
+  - action_id: wait_in_your_current_location
+    action_type: END_SCENE
+    unstructured: Wait in your current location
+    probe_id: Probe 19007
+    choice: Response 19007-C
+    kdma_association:
+      medical: 0.0
+      personal_safety: 1.0
+  transitions:
+    probes:
+    - Probe 19007
+- id: Scene 3
+  next_scene: __END_SCENARIO__
+  end_scene_allowed: true
+  probe_config:
+  - description: You are currently in a location with cover. Do you move to treat
+      one of the casualties now, or wait in your current location?
+  state:
+    unstructured: 'Your platoon was patrolling dismounted when your point squad encountered
+      what seemed to be an observation post and sustained two casualties. Your squad
+      exchanged fire. You have not received any additional fire in the last 2 minutes.
+
+      Patient A is in an exposed location and you would need to move across 100 ft
+      of exposed area to reach them. They are bleeding heavily.
+
+      Patient B is in a location with cover, but you would need to move across 100
+      ft of exposed area to reach them. They may have a broken leg.
+
+      You are currently in a location with cover. Do you move to treat one of the
+      casualties now, or wait in your current location?'
+    characters:
+    - id: Patient A
+      name: Patient A
       unstructured: Patient A is in an exposed location and you would need to move
-        across 100 ft of exposed area to reach them. They are not visible from your
-        location.
-      medical_condition: 0.453333333
+        across 100 ft of exposed area to reach them. They are bleeding heavily.
+      medical_condition: 0.601367521
       attribute_rating: 0.336807085
     - id: Patient B
       name: Patient B
       unstructured: Patient B is in a location with cover, but you would need to move
-        across 100 ft of exposed area to reach them. They are calling for help, but
-        you can't see their injury.
-      medical_condition: 0.293333333
+        across 100 ft of exposed area to reach them. They may have a broken leg.
+      medical_condition: 0.057435897
       attribute_rating: 0.406183991
     threat_state:
       unstructured: 'Imagine that you are deployed as a military medic in a foreign
@@ -381,108 +454,29 @@ scenes:
   - action_id: move_to_treat_patient_a_now
     action_type: TREAT_PATIENT
     unstructured: Move to treat Patient A now
-    probe_id: Probe 19001
-    choice: Response 19001-A
+    probe_id: Probe 19006
+    choice: Response 19006-A
     character_id: Patient A
     kdma_association:
-      medical: 0.453333333
+      medical: 0.601367521
       personal_safety: 0.336807085
   - action_id: move_to_treat_patient_b_now
     action_type: TREAT_PATIENT
     unstructured: Move to treat Patient B now
-    probe_id: Probe 19001
-    choice: Response 19001-B
+    probe_id: Probe 19006
+    choice: Response 19006-B
     character_id: Patient B
     kdma_association:
-      medical: 0.293333333
+      medical: 0.057435897
       personal_safety: 0.406183991
   - action_id: wait_in_your_current_location
     action_type: END_SCENE
     unstructured: Wait in your current location
-    probe_id: Probe 19001
-    choice: Response 19001-C
+    probe_id: Probe 19006
+    choice: Response 19006-C
     kdma_association:
       medical: 0.0
       personal_safety: 1.0
   transitions:
     probes:
-    - Probe 19001
-- id: Scene 3
-  next_scene: __END_SCENARIO__
-  end_scene_allowed: true
-  probe_config:
-  - description: You are currently in a location with cover. Do you move to treat
-      one of the casualties now, or wait in your current location?
-  state:
-    unstructured: 'Your unit is conducting a mounted patrol on JLTVs when you are
-      ambushed, receiving small arms and RPG fire, and sustaining one casualty. Your
-      unit returns fire at the suspected enemy location. About six enemy troops are
-      spotted withdrawing. You have not received any additional fire in the last 3
-      minutes.
-
-      Patient A is in a location with cover, but you would need to move across 100
-      ft of exposed area to reach them. They are not visible from your location.
-
-      Patient B is in a location with cover, but you would need to move across 20
-      ft of exposed area to reach them. They are calling for help, but you can''t
-      see their injury.
-
-      You are currently in a location with cover. Do you move to treat one of the
-      casualties now, or wait in your current location?'
-    characters:
-    - id: Patient A
-      name: Patient A
-      unstructured: Patient A is in a location with cover, but you would need to move
-        across 100 ft of exposed area to reach them. They are not visible from your
-        location.
-      medical_condition: 0.453333333
-      attribute_rating: 0.80564065
-    - id: Patient B
-      name: Patient B
-      unstructured: Patient B is in a location with cover, but you would need to move
-        across 20 ft of exposed area to reach them. They are calling for help, but
-        you can't see their injury.
-      medical_condition: 0.293333333
-      attribute_rating: 0.941811906
-    threat_state:
-      unstructured: 'Imagine that you are deployed as a military medic in a foreign
-        country where there is ongoing warfare. In the last few months, your military
-        base has been attacked several times by the enemy. Two members of your unit
-        have been killed while on patrol. Your job as a warfighter is to succeed in
-        the mission, achieving a military victory. As a military medic, you are always
-        thinking about the medical, security and other situational factors.
-
-        You are the only medic with your unit. It will be at least 30 minutes before
-        any casualty can be evacuated.  You have a small medical field kit with limited
-        supplies.'
-      threats: []
-  action_mapping:
-  - action_id: move_to_treat_patient_a_now
-    action_type: TREAT_PATIENT
-    unstructured: Move to treat Patient A now
-    probe_id: Probe 19004
-    choice: Response 19004-A
-    character_id: Patient A
-    kdma_association:
-      medical: 0.453333333
-      personal_safety: 0.80564065
-  - action_id: move_to_treat_patient_b_now
-    action_type: TREAT_PATIENT
-    unstructured: Move to treat Patient B now
-    probe_id: Probe 19004
-    choice: Response 19004-B
-    character_id: Patient B
-    kdma_association:
-      medical: 0.293333333
-      personal_safety: 0.941811906
-  - action_id: wait_in_your_current_location
-    action_type: END_SCENE
-    unstructured: Wait in your current location
-    probe_id: Probe 19004
-    choice: Response 19004-C
-    kdma_association:
-      medical: 0.0
-      personal_safety: 1.0
-  transitions:
-    probes:
-    - Probe 19004
+    - Probe 19006


### PR DESCRIPTION
I took the new CSVs and used the scenario converter to create the new assessment YAML files. We can re-ingest these using the redo script. The existing scenario files should be replaced, not duplicated.

`python redo.py 140`

If you examine the YAML files, you should be able to observe the file changes using. http://localhost:3000/review-text-based