### PR TITLE
ITM-1373: Ingest Observation YAMLs June 2026

### DIFF
--- a/scripts/_1_4_4_june_scenario_files.py
+++ b/scripts/_1_4_4_june_scenario_files.py
@@ -1,0 +1,29 @@
+import os, yaml
+
+    
+SCENARIOS_FOLDER = 'phase2/june2026/admrun'
+
+
+def main(mongo_db):
+    files = sorted(os.listdir(SCENARIOS_FOLDER))
+
+    for file in files:
+        path = os.path.join(SCENARIOS_FOLDER, file)
+        with open(path) as f:
+            yaml_obj = yaml.safe_load(f)
+            yaml_obj["evalNumber"] = 17
+            yaml_obj["evalName"] = "Phase 2 June 2026 Collaboration"
+
+            scenarios = mongo_db["scenarios"]
+            scenario_id = yaml_obj.get("id")
+
+            if scenario_id:
+                result = scenarios.replace_one(
+                    {"id": scenario_id},
+                    yaml_obj,
+                    upsert=True
+                )
+                if result.matched_count:
+                    print(f"Replaced: {file}")
+                else:
+                    print(f"Uploaded: {file}")


### PR DESCRIPTION
For the ADM results pages to work, we need to ingest the observation YAML files. 

`python deployment_script.py` or `python redo.py 144`

Now we can go to [admin](http://localhost:3000/admin) and toggle on the adm results pages
<img width="1072" height="136" alt="Screenshot 2026-06-09 at 10 23 13 AM" src="https://github.com/user-attachments/assets/8289b09d-864d-4fef-b5c8-67ea69d976f2" />

Each of the three pages should now populate for June 2026 (page may need a refresh first).
http://localhost:3000/adm-results
http://localhost:3000/results
http://localhost:3000/adm-probe-responses 