### PR TITLE
ITM-1385 Update TCCC Triage Performance format

### DIFF
--- a/scripts/_1_4_5_tccc_triage_perf_to_decimal.py
+++ b/scripts/_1_4_5_tccc_triage_perf_to_decimal.py
@@ -1,0 +1,16 @@
+def main(mongo_db):
+    counter = 0
+    tcccResults = mongo_db['tcccResults']
+    for doc in tcccResults.find(
+        {"tccc_analysis.TCCC Triage Performance": {"$exists": True}}
+    ):
+        old_format = float(doc["tccc_analysis"]["TCCC Triage Performance"])
+        new_format = str(old_format / 100)
+
+        tcccResults.update_one({"_id": doc["_id"]}, 
+            {"$set": {"tccc_analysis.TCCC Triage Performance": new_format}}
+        )
+
+        counter += 1
+    
+    print(f"Finished updating {counter} documents")


### PR DESCRIPTION
Summary

This PR changes the TCCC Triage Performance metric format from a percentage to a decimal to match the format of the ACC measures.

Only run this script a single time. It divides each value by 100, so a second run would double-convert and corrupt the data (e.g. 0.56 → 0.0056).

How to test

Grab the latest DB backup from S3
Run `python redo.py 145` You should see a count of documents updated printed at the end.
Spot-check

The data lives in the `tcccResults` collection under `tccc_analysis`

Look up `{'pid': '202604130'}` TCCC Triage Performance should have gone from 12.5 to 0.125.
Check the whole collection: every TCCC Triage Performance value should now be between 0 and 1 (decimals), whereas before they were all greater than 1 (percentages).