### PR TITLE
Remove spurious text documents

### DIFF
--- a/scripts/_1_4_7_remove_dup.py
+++ b/scripts/_1_4_7_remove_dup.py
@@ -1,0 +1,12 @@
+from bson import ObjectId
+def main(mongo_db):
+    to_remove = ['6a3ac97162f0ee4fb635f453', '6a3ac97162f0eef84a35f450', '6a3ac8c262f0ee51c335f44a',
+                 '6a3ac8c262f0ee185335f448', '6a3ac8c262f0ee5e3035f446', '6a3ac8c262f0ee304935f444']
+    
+    text_scenario_collection = mongo_db['userScenarioResults']
+
+    result = text_scenario_collection.delete_many({
+        '_id': {'$in': [ObjectId(id) for id in to_remove]}
+    })
+
+    print(f"Deleted {result.deleted_count} spurious text documents")


### PR DESCRIPTION
PID: 202606144 had 12 documents instead of 6. This script removes the bad documents so I can properly rescore this participant. 

`python deployment_script.py` or `python redo.py 147`

NOTE: This requires a backup from at least 6/24/26.