### PR TITLE
Itm 1387: RQ1 and cleaning up a mess

### DIFF
--- a/scripts/_0_8_3_June_Collab_Comparison_Generation.py
+++ b/scripts/_0_8_3_June_Collab_Comparison_Generation.py
@@ -35,7 +35,7 @@ def main(mongoDB, EVAL_NUMBER=8):
             session_id = entry.get('individualSessionId') if is_individual_mf else entry.get('combinedSessionId')
         elif EVAL_NUMBER == 17:
             # SS-assess feeds the AF-SS 2D block (scored under its own combined AF+SS session);
-            # everything else (AF/PS, binary or trinary) uses its group's combinedSessionId.
+            # every other doc (AF/PS, binary or trinary) uses its group's combinedSessionId.
             session_id = entry.get('AF-SS_sessionId') if 'SS' in scenario_id else entry.get('combinedSessionId')
         else:
             session_id = entry.get('combinedSessionId')
@@ -60,18 +60,15 @@ def main(mongoDB, EVAL_NUMBER=8):
                 scenario_attribute = next((x for x in ['MF', 'SS', 'PS', 'AF'] if x in scenario_id), None)
 
                 if EVAL_NUMBER == 17:
-                    doc_is_trinary = 'trinary' in scenario_id
                     if 'SS' in scenario_id:
-                        # SS-assess drives ONLY the AF-SS 2D observe block
+                        # SS-assess drives ONLY the AF-SS 2D observe block (binary only — no trinary counterpart)
                         if 'AF-SS' not in page_scenario:
                             continue
                     else:
-                        # AF or PS single-attribute block: attribute + binary/trinary variant must match,
-                        # and exclude the AF-SS page (handled by the SS doc above)
+                        # Each attribute's observe pages (BOTH the binary and the
+                        # trinary blocks) are scored against BOTH the delegator's binary and trinary sessions
                         attr = 'AF' if 'AF' in scenario_id else 'PS'
                         if attr not in page_scenario or 'AF-SS' in page_scenario:
-                            continue
-                        if doc_is_trinary != ('trinary' in page_scenario):
                             continue
                 elif EVAL_NUMBER == 15:
                     if is_individual_mf:
@@ -132,8 +129,9 @@ def main(mongoDB, EVAL_NUMBER=8):
                             'adm_alignment_target': survey['results'][page]['admTarget'],
                             'evalNumber': EVAL_NUMBER
                         }
-                        # Eval 17: mark binary vs trinary so the dashboard can split the
-                        # Observed_ADM (binary) and DelegatorTRI columns.
+                        # Eval 17: tag which delegator framework this score used (binary vs trinary probes)
+                        # so the dashboard routes it to Delegator|Observed_ADM vs DelegatorTRI|Observed_ADM.
+                        # The tag comes from THIS text doc's variant, not the observe page's variant.
                         if EVAL_NUMBER == 17:
                             document['session_type'] = 'trinary' if 'trinary' in scenario_id else 'binary'
                         send_document_to_mongo(comparison_collection, document)

--- a/scripts/_0_8_3_June_Collab_Comparison_Generation.py
+++ b/scripts/_0_8_3_June_Collab_Comparison_Generation.py
@@ -11,7 +11,7 @@ def main(mongoDB, EVAL_NUMBER=8):
     text_scenario_collection = mongoDB['userScenarioResults']
     delegation_collection = mongoDB['surveyResults']
     comparison_collection = mongoDB['humanToADMComparison']
-    
+
     # Let's you rerun script when necessary to repopulate as more participants come in
     comparison_collection.delete_many({"evalNumber": EVAL_NUMBER})
     medic_collection = mongoDB['admMedics']
@@ -33,8 +33,20 @@ def main(mongoDB, EVAL_NUMBER=8):
         if EVAL_NUMBER == 15:
             is_individual_mf = 'MF' in scenario_id and 'SS' not in scenario_id
             session_id = entry.get('individualSessionId') if is_individual_mf else entry.get('combinedSessionId')
+        elif EVAL_NUMBER == 17:
+            # SS-assess feeds the AF-SS 2D block (scored under its own combined AF+SS session);
+            # everything else (AF/PS, binary or trinary) uses its group's combinedSessionId.
+            session_id = entry.get('AF-SS_sessionId') if 'SS' in scenario_id else entry.get('combinedSessionId')
         else:
             session_id = entry.get('combinedSessionId')
+
+        # Eval 17: MF is assessed for KDMA profiling only — no MF delegation block, so skip the doc entirely.
+        if EVAL_NUMBER == 17 and 'MF' in scenario_id:
+            continue
+        if EVAL_NUMBER == 17 and not session_id:
+            print(f"No session id for eval 17 text scenario {scenario_id} (pid {entry.get('participantID')})")
+            continue
+
         pid = entry.get('participantID')
         survey = list(delegation_collection.find({"results.Participant ID Page.questions.Participant ID.response": pid}))
         if len(survey) == 0:
@@ -47,7 +59,21 @@ def main(mongoDB, EVAL_NUMBER=8):
                 page_scenario = survey['results'][page]['scenarioIndex']
                 scenario_attribute = next((x for x in ['MF', 'SS', 'PS', 'AF'] if x in scenario_id), None)
 
-                if EVAL_NUMBER == 15:
+                if EVAL_NUMBER == 17:
+                    doc_is_trinary = 'trinary' in scenario_id
+                    if 'SS' in scenario_id:
+                        # SS-assess drives ONLY the AF-SS 2D observe block
+                        if 'AF-SS' not in page_scenario:
+                            continue
+                    else:
+                        # AF or PS single-attribute block: attribute + binary/trinary variant must match,
+                        # and exclude the AF-SS page (handled by the SS doc above)
+                        attr = 'AF' if 'AF' in scenario_id else 'PS'
+                        if attr not in page_scenario or 'AF-SS' in page_scenario:
+                            continue
+                        if doc_is_trinary != ('trinary' in page_scenario):
+                            continue
+                elif EVAL_NUMBER == 15:
                     if is_individual_mf:
                         if 'MF' not in page_scenario or 'SS' in page_scenario:
                             continue
@@ -65,12 +91,14 @@ def main(mongoDB, EVAL_NUMBER=8):
                         continue
 
                 medic = medic_collection.find_one({'evalNumber': EVAL_NUMBER, 'name': page})
+                if not medic:
+                    continue
                 if 'combined' in page_scenario:
                     adm_sessions = medic['admSessionIdsByScenario']
                     # Create a comparison for each scenario in the combined ADM
                     for adm_scenario_id, adm_session in adm_sessions.items():
                         res = requests.get(f'{ADEPT_URL}api/v1/alignment/compare_sessions?session_id_1={session_id}&session_id_2={adm_session}').json()
-                        
+
                         if res is not None and 'score' in res:
                             document = {
                                 'pid': pid,
@@ -104,6 +132,10 @@ def main(mongoDB, EVAL_NUMBER=8):
                             'adm_alignment_target': survey['results'][page]['admTarget'],
                             'evalNumber': EVAL_NUMBER
                         }
+                        # Eval 17: mark binary vs trinary so the dashboard can split the
+                        # Observed_ADM (binary) and DelegatorTRI columns.
+                        if EVAL_NUMBER == 17:
+                            document['session_type'] = 'trinary' if 'trinary' in scenario_id else 'binary'
                         send_document_to_mongo(comparison_collection, document)
                     else:
                         print(f'Error getting comparison for scenarios {scenario_id} and {page_scenario} with text session {session_id} and adm session {adm_session}', res)

--- a/scripts/_1_4_9_rq1_june26.py
+++ b/scripts/_1_4_9_rq1_june26.py
@@ -1,5 +1,11 @@
 from scripts._0_8_3_June_Collab_Comparison_Generation import main as gen_comp
 from bson import ObjectId
+
+
+def rescore_observed_adms():
+    pass
+
+
 def main(mongo_db):
     text_collec = mongo_db['userScenarioResults']
     # pid to remove bad second run: 137, 148, 152, 160
@@ -9,4 +15,13 @@ def main(mongo_db):
         '202606152': ['6a3d90b662f0eedd5f35fade', '6a3d90b662f0ee56da35fae1'],
         '202606160': ['6a3e6b5062f0ee046635fbda', '6a3e6b4f62f0eeb4dc35fbd7']
     }
-    gen_comp(mongo_db, EVAL_NUMBER=17)
+
+    # remove bad text docs before we make any comparison scores
+    for pid, oid_strings in bad_text_docs.items():
+        object_ids = [ObjectId(oid) for oid in oid_strings]
+        text_collec.delete_many({'_id': {'$in': object_ids}})
+
+
+    #re score observed adm run alignment scores
+    rescore_observed_adms()
+    #gen_comp(mongo_db, EVAL_NUMBER=17)

--- a/scripts/_1_4_9_rq1_june26.py
+++ b/scripts/_1_4_9_rq1_june26.py
@@ -1,0 +1,12 @@
+from scripts._0_8_3_June_Collab_Comparison_Generation import main as gen_comp
+from bson import ObjectId
+def main(mongo_db):
+    text_collec = mongo_db['userScenarioResults']
+    # pid to remove bad second run: 137, 148, 152, 160
+    bad_text_docs = {
+        '202606137': ['6a344ae462f0ee5e0f35ea25', '6a344ae462f0ee04af35ea27', '6a344ae462f0eeb9e435ea29', '6a344ae462f0ee7f9735ea2b'],
+        '202606148': ['6a3dbb3162f0ee4f6f35fb4b', '6a3dbb3162f0eea81835fb49', '6a3dbb3162f0eed38d35fb47', '6a3dbb3162f0ee2ffd35fb45', '6a3dbb0e62f0ee186d35fb41', '6a3dbb0e62f0ee68da35fb3f'],
+        '202606152': ['6a3d90b662f0eedd5f35fade', '6a3d90b662f0ee56da35fae1'],
+        '202606160': ['6a3e6b5062f0ee046635fbda', '6a3e6b4f62f0eeb4dc35fbd7']
+    }
+    gen_comp(mongo_db, EVAL_NUMBER=17)

--- a/scripts/_1_4_9_rq1_june26.py
+++ b/scripts/_1_4_9_rq1_june26.py
@@ -1,30 +1,423 @@
-from scripts._0_8_3_June_Collab_Comparison_Generation import main as gen_comp
+import os
+from pathlib import Path
+
+import pandas as pd
+import requests
 from bson import ObjectId
 from decouple import config
-import requests
+
+import utils.db_utils as db_utils
+from scripts._0_8_3_June_Collab_Comparison_Generation import main as gen_comp
 
 ADEPT_URL = config('ADEPT_URL')
-def rescore_observed_adms(observed_runs):
-    for adm in observed_runs:
-        results = adm.get('results', '')
-        sid = results.get('ta1_session_id', None)
-        target = adm.get('alignment_target')
-        existing_score = results.get('alignment_score')
 
-        payload = {'session_id': sid, 'target_id': target}
-        new_score = (requests.get(f'{ADEPT_URL}api/v1/alignment/session', params=payload))
-        print(new_score)
-        print(new_score.json())
-
-        if existing_score != new_score:
-            print('Difference In Scores \n')
-            print(f'New Score: {new_score}')
-            print(f'Existing Score: {existing_score}')
-            print(f'ADM Target: {target}')
+EVAL_NUMBER = 17
+HUMAN_TEXT_COLLECTION = 'userScenarioResults'
+# threshold
+SCORE_TOLERANCE = 1e-6
 
 
-def main(mongo_db):
-    text_collec = mongo_db['userScenarioResults']
+def score_difference(a, b):
+    return a is None or b is None or abs(a - b) > SCORE_TOLERANCE
+
+
+def get_session_id(adm):
+    results = adm.get('results') or {}
+    if results.get('ta1_session_id'):
+        return results['ta1_session_id']
+    print("Error - Missing TA1 Session ID")
+    return None
+
+
+def get_probes(medic):
+    elements = medic.get('elements') or []
+    rows = elements[0].get('rows', []) if elements else []
+    probes = [
+        {'probe': {'choice': row.get('choice_id'), 'probe_id': row.get('probe_id')}}
+        for row in rows
+    ]
+    scenario = rows[0].get('scenario_id') if rows else medic.get('scenarioName')
+    return probes, scenario
+
+
+def build_set_dict(adm, new_sid, new_score):
+    # Build dict for $set changed. Changes all occurences of ta1 session id or score
+    old_sid = get_session_id(adm)
+    set_ops = {}
+
+    if isinstance(adm.get('results'), dict):
+        set_ops['results.ta1_session_id'] = new_sid
+        set_ops['results.alignment_score'] = new_score
+
+    evaluation = adm.get('evaluation')
+    if isinstance(evaluation, dict) and isinstance(evaluation.get('results'), dict):
+        set_ops['evaluation.results.ta1_session_id'] = new_sid
+        set_ops['evaluation.results.alignment_score'] = new_score
+
+    for i, item in enumerate(adm.get('history', []) or []):
+        command = item.get('command')
+        params = item.get('parameters') or {}
+
+        if command == 'TA1 Session ID':
+            set_ops[f'history.{i}.response'] = new_sid
+        elif command == 'TA1 Session Alignment':
+            if params.get('session_id') == old_sid:
+                set_ops[f'history.{i}.parameters.session_id'] = new_sid
+            if isinstance(item.get('response'), dict) and 'score' in item['response']:
+                set_ops[f'history.{i}.response.score'] = new_score
+        elif command == 'Alignment Target':
+            # parameters.session_id here is the TA1 session id
+            if params.get('session_id') == old_sid:
+                set_ops[f'history.{i}.parameters.session_id'] = new_sid
+
+    return set_ops
+
+
+def rescore_medics(mongo_db):
+    '''
+    For each eval 17 admMedics run, resend its probes to a fresh ADEPT session,
+    re-score against the run's target, locate the matching admTargetRuns
+    document, and return a per-run record. Does not modify the database.
+    '''
+    medic_collection = mongo_db['admMedics']
+    adm_run_collection = mongo_db['admTargetRuns']
+
+    medics = list(medic_collection.find({'evalNumber': EVAL_NUMBER}))
+    total = len(medics)
+    print(f"Found {total} admMedics document(s) for eval {EVAL_NUMBER}.\n")
+
+    records = []
+    for idx, medic in enumerate(medics, start=1):
+        medic_name = medic.get('name')
+        adm_name = medic.get('admName')
+        target = medic.get('target')
+        old_sid = medic.get('admSessionId')
+        medic_existing = medic.get('alignmentScore')
+
+        probes, scenario = get_probes(medic)
+
+        print(f"[{idx}/{total}] {medic_name} | {adm_name} | {scenario} | target={target}")
+
+        notes = []
+
+        if not probes:
+            print('  No probe responses on medic, skipping')
+            records.append(make_medic_row(medic, None, scenario, target, old_sid, None,
+                                              medic_existing, None, None, ['no probe responses on medic']))
+            continue
+        if not target:
+            print('  No target on medic, skipping')
+            records.append(make_medic_row(medic, None, scenario, target, old_sid, None,
+                                              medic_existing, None, None, ['no target on medic']))
+            continue
+
+        # Fresh session: the original session ids no longer resolve after the
+        # ADEPT memory wipe, so we rebuild the session from the stored probes.
+        new_sid = requests.post(f'{ADEPT_URL}api/v1/new_session').text.replace('"', '').strip()
+        db_utils.send_probes(f'{ADEPT_URL}api/v1/response', probes, new_sid, scenario)
+
+        alignment_params = {'session_id': new_sid, 'target_id': target}
+        if medic.get('subpop'):
+            alignment_params['enable_subpop'] = medic['subpop']
+        alignment = requests.get(
+            f'{ADEPT_URL}api/v1/alignment/session', params=alignment_params
+        ).json()
+        new_score = alignment.get('score') if isinstance(alignment, dict) else None
+        if new_score is None:
+            notes.append('ADEPT returned no score')
+
+        # Join to the admTargetRuns counterpart on the (pre-update) session id.
+        adm_run = adm_run_collection.find_one({'results.ta1_session_id': old_sid}) if old_sid else None
+        run_existing = None
+        if adm_run is None:
+            notes.append('no matching admTargetRuns document')
+        else:
+            run_existing = (adm_run.get('results') or {}).get('alignment_score')
+
+        print(f"  existing(medic)={medic_existing} existing(run)={run_existing} new={new_score}")
+        if notes:
+            print(f"  notes: {'; '.join(notes)}")
+
+        records.append(make_medic_row(medic, adm_run, scenario, target, old_sid, new_sid,
+                                          medic_existing, run_existing, new_score, notes))
+
+    return records
+
+
+def make_medic_row(medic, adm_run, scenario, target, old_sid, new_sid,
+                       medic_existing, run_existing, new_score, notes):
+    score_discrepancy = (
+        new_score is None
+        or score_difference(new_score, medic_existing)
+        or (adm_run is not None and score_difference(new_score, run_existing))
+    )
+    is_discrepancy = score_discrepancy or bool(notes)
+    difference = (
+        abs(new_score - medic_existing)
+        if new_score is not None and medic_existing is not None
+        else None
+    )
+    return {
+        'medic': medic,
+        'adm_run': adm_run,
+        'medic_id': medic.get('_id'),
+        'adm_run_id': adm_run.get('_id') if adm_run else None,
+        'medic_name': medic.get('name'),
+        'adm_name': medic.get('admName'),
+        'scenario': scenario,
+        'target': target,
+        'old_session_id': old_sid,
+        'new_session_id': new_sid,
+        'medic_existing_score': medic_existing,
+        'run_existing_score': run_existing,
+        'new_score': new_score,
+        'difference': difference,
+        'note': '; '.join(notes),
+        'is_discrepancy': is_discrepancy,
+    }
+
+
+def apply_medic_updates(mongo_db, records):
+    '''
+    Refresh the ta1 session id and alignment score on both documents for each
+    rescored run: the admMedics doc (admSessionId / alignmentScore) and its
+    matched admTargetRuns doc (every place those fields appear). Runs where ADEPT
+    returned no score are skipped so we never write a null over a real value.
+    '''
+    medic_collection = mongo_db['admMedics']
+    run_collection = mongo_db['admTargetRuns']
+    medics_updated = runs_updated = skipped = 0
+
+    for rec in records:
+        if rec['new_score'] is None or not rec['new_session_id']:
+            print(f"  Skipping {rec['medic_name']}: no new score/session from ADEPT")
+            skipped += 1
+            continue
+
+        # admMedics: session id + alignment score live at the top level
+        medic_result = medic_collection.update_one(
+            {'_id': rec['medic_id']},
+            {'$set': {'admSessionId': rec['new_session_id'], 'alignmentScore': rec['new_score']}},
+        )
+        medics_updated += medic_result.modified_count
+
+        # admTargetRuns: refresh every location the fields appear in
+        if rec['adm_run'] is not None:
+            set_ops = build_set_dict(rec['adm_run'], rec['new_session_id'], rec['new_score'])
+            if set_ops:
+                run_result = run_collection.update_one({'_id': rec['adm_run_id']}, {'$set': set_ops})
+                runs_updated += run_result.modified_count
+        else:
+            print(f"  {rec['medic_name']}: medic updated, but no admTargetRuns counterpart to update")
+
+    print(f"\nApplied ADM updates: {medics_updated} admMedics, {runs_updated} admTargetRuns, {skipped} skipped.")
+
+
+# ---------------------------------------------------------------------------
+# Human side (userScenarioResults)
+# ---------------------------------------------------------------------------
+
+# The human ADEPT sessions are still live on the server, so we do NOT resend
+# probes -- we just re-query each stored session id and compare. Each pairing is
+# (session id field, mostLeastAligned field, allow_multiattribute_targets?) and
+# matches how the dashboard originally scored eval 17:
+#   * combinedSessionId -> combinedMostLeastAligned (no multiattribute)
+#   * AF-SS_sessionId    -> AF-SS_mostLeastAligned   (multiattribute=true)
+# A doc only carries AF-SS_sessionId if it is an AF or SS (non-trinary) doc, so
+# driving off the stored fields reproduces the dashboard grouping automatically.
+HUMAN_ALIGNMENT_CHECKS = [
+    ('combinedSessionId', 'combinedMostLeastAligned', False),
+    ('AF-SS_sessionId', 'AF-SS_mostLeastAligned', True),
+]
+
+
+def get_ordered_alignment(session_id, allow_multiattribute=False):
+    # calls get_ordered_alignment the same way the dashboard woul
+    params = {'session_id': session_id}
+    if allow_multiattribute:
+        params['allow_multiattribute_targets'] = 'true'
+    data = requests.get(f'{ADEPT_URL}api/v1/get_ordered_alignment', params=params).json()
+    if not isinstance(data, list):
+        data = []
+    filtered = [
+        obj for obj in data
+        if isinstance(obj, dict) and not any('-group-' in str(key).lower() for key in obj.keys())
+    ]
+    return [{'target': None, 'response': filtered}]
+
+ATTRIBUTE_TOKENS = ('AF', 'PS', 'SS', 'MF')
+
+
+def t_type(target_id):
+    present = [attr for attr in ATTRIBUTE_TOKENS if attr in target_id]
+    if 'AF' in present and 'SS' in present:
+        return 'AF-SS'
+    return present[0] if len(present) == 1 else None
+
+
+def scenario_attr(scenario_id):
+    #June2026-PS-assess-trinary -> PS. 
+    parts = (scenario_id or '').split('-')
+    return parts[1] if len(parts) > 1 else None
+
+
+def order_targets(mla):
+    # ensure order
+    if not isinstance(mla, list) or not mla:
+        return None
+    block = mla[0]
+    if not isinstance(block, dict):
+        return None
+    response = block.get('response')
+    if not isinstance(response, list):
+        return None
+
+    targets = []
+    for obj in response:
+        if isinstance(obj, dict):
+            targets.extend(obj.items())
+    return targets
+
+
+def ml_by_type(mla):
+    # each type present to {'most': (target, score), 'least': (target, score)}
+    targets = order_targets(mla)
+    if targets is None:
+        return None
+
+    by_type = {}
+    for target_id, score in targets:
+        attr = t_type(target_id)
+        if attr is None:
+            continue
+        if attr not in by_type:
+            by_type[attr] = {'most': (target_id, score), 'least': (target_id, score)}
+        else:
+            by_type[attr]['least'] = (target_id, score)  # keep pushing least back
+    return by_type
+
+
+def break_down_alignment(mla, attribute):
+    # most_target, most_score, least_target, least_score
+    by_type = ml_by_type(mla)
+    if not by_type or attribute not in by_type:
+        return (None, None, None, None)
+    entry = by_type[attribute]
+    most_target, most_score = entry['most']
+    least_target, least_score = entry['least']
+    return (most_target, most_score, least_target, least_score)
+
+
+def rescore_humans(mongo_db):
+    # rescore the session ids already existing on the adept server and compare to scores stored in db
+    collection = mongo_db[HUMAN_TEXT_COLLECTION]
+    docs = list(collection.find({'evalNumber': EVAL_NUMBER}))
+    print(f"\nFound {len(docs)} {HUMAN_TEXT_COLLECTION} doc(s) for eval {EVAL_NUMBER}.")
+
+    # the alignment cache will stop us from making the same exact server calls
+    alignment_cache = {}
+    rows = []
+    for doc in docs:
+        attribute = scenario_attr(doc.get('scenario_id'))
+        rows.append(make_human_row(doc, 'combinedSessionId', 'combinedMostLeastAligned',
+                                    attribute, False, alignment_cache))
+        if doc.get('AF-SS_sessionId'):
+            rows.append(make_human_row(doc, 'AF-SS_sessionId', 'AF-SS_mostLeastAligned',
+                                        'AF-SS', True, alignment_cache))
+
+    return rows
+
+
+def make_human_row(doc, session_field, mla_field, attribute, multiattr, alignment_cache):
+    session_id = doc.get(session_field)
+
+    new_alignment = None
+    if session_id:
+        cache_key = (session_id, multiattr)
+        if cache_key not in alignment_cache:
+            alignment_cache[cache_key] = get_ordered_alignment(session_id, allow_multiattribute=multiattr)
+        new_alignment = alignment_cache[cache_key]
+
+    stored_alignment = doc.get(mla_field)
+    old_most_t, old_most_s, old_least_t, old_least_s = break_down_alignment(stored_alignment, attribute)
+    new_most_t, new_most_s, new_least_t, new_least_s = break_down_alignment(new_alignment, attribute)
+
+    note = '' if session_id else f'no {session_field} on doc'
+    # discrepancy = the most- or least-aligned target of this type changed identity
+    changed = (old_most_t != new_most_t) or (old_least_t != new_least_t)
+
+    flag = 'DISCREPANCY' if changed else 'OK'
+    print(f"  {doc.get('participantID')} | {doc.get('scenario_id')} | {attribute} -> {flag}")
+
+    return {
+        'doc_id': doc.get('_id'),
+        'participantID': doc.get('participantID'),
+        'scenario_id': doc.get('scenario_id'),
+        'attribute': attribute,
+        'mla_field': mla_field,
+        'session_id': session_id,
+        'old_most_target': old_most_t,
+        'old_most_score': old_most_s,
+        'old_least_target': old_least_t,
+        'old_least_score': old_least_s,
+        'new_most_target': new_most_t,
+        'new_most_score': new_most_s,
+        'new_least_target': new_least_t,
+        'new_least_score': new_least_s,
+        'changed': changed,
+        'note': note,
+        # full fetched array kept so write mode can overwrite the stored field
+        'new_alignment': new_alignment,
+    }
+
+
+def apply_human_updates(mongo_db, rows):
+    # overwrites the db with the accurate scores if necessary for the row
+    # Note: each human has 8 corresponding rows
+    collection = mongo_db[HUMAN_TEXT_COLLECTION]
+    updated = 0
+    for row in rows:
+        if not row['changed'] or row['new_alignment'] is None:
+            continue
+        result = collection.update_one(
+            {'_id': row['doc_id']},
+            {'$set': {row['mla_field']: row['new_alignment']}},
+        )
+        updated += result.modified_count
+
+    print(f"\nApplied human updates: {updated} mostLeastAligned field(s) overwritten where the most/least aligned target changed.")
+
+def write_discrepancies(adm_records, human_rows):
+   # will be two sheets, compares old scores/alignment to new
+    script_dir = Path(os.path.dirname(os.path.abspath(__file__)))
+    root_dir = script_dir.parent
+    excel_path = os.path.join(root_dir, 'eval17_rescore_discrepancies.xlsx')
+
+    adm_columns = ['medic_name', 'adm_name', 'scenario', 'target',
+                   'old_session_id', 'new_session_id',
+                   'medic_existing_score', 'new_score', 'difference', 'note']
+    adm_out = [
+        {key: rec[key] for key in adm_columns}
+        for rec in adm_records if rec['is_discrepancy']
+    ]
+
+    human_columns = ['participantID', 'scenario_id', 'attribute', 'session_id',
+                     'old_most_target', 'old_most_score', 'old_least_target', 'old_least_score',
+                     'new_most_target', 'new_most_score', 'new_least_target', 'new_least_score',
+                     'changed', 'note']
+    human_out = [{key: row[key] for key in human_columns} for row in human_rows]
+
+    with pd.ExcelWriter(excel_path) as writer:
+        pd.DataFrame(adm_out, columns=adm_columns).to_excel(writer, sheet_name='adm', index=False)
+        pd.DataFrame(human_out, columns=human_columns).to_excel(writer, sheet_name='human', index=False)
+
+    changed_count = sum(1 for row in human_rows if row['changed'])
+    print(f"\nWrote report to {excel_path}")
+    print(f"  adm sheet:   {len(adm_out)} discrepancy row(s)")
+    print(f"  human sheet: {len(human_out)} row(s) ({changed_count} changed)")
+
+def main(mongo_db, write_to_db=False):
+    text_collec = mongo_db[HUMAN_TEXT_COLLECTION]
     # pid to remove bad second run: 137, 148, 152, 160
     bad_text_docs = {
         '202606137': ['6a344ae462f0ee5e0f35ea25', '6a344ae462f0ee04af35ea27', '6a344ae462f0eeb9e435ea29', '6a344ae462f0ee7f9735ea2b'],
@@ -38,8 +431,14 @@ def main(mongo_db):
         object_ids = [ObjectId(oid) for oid in oid_strings]
         text_collec.delete_many({'_id': {'$in': object_ids}})
 
-    observed_adms = list(mongo_db['admTargetRuns'].find({'evalNumber': 17}))
-    #re score observed adm run alignment scores
-    rescore_observed_adms(observed_adms)
+    # re-score the observed adm runs (admMedics + admTargetRuns) and the human runs
+    adm_records = rescore_medics(mongo_db)
+    human_rows = rescore_humans(mongo_db)
+
+    # dump to excel
+    write_discrepancies(adm_records, human_rows)
+
+    if write_to_db:
+        apply_medic_updates(mongo_db, adm_records)
+        apply_human_updates(mongo_db, human_rows)
     #gen_comp(mongo_db, EVAL_NUMBER=17)
-    

--- a/scripts/_1_4_9_rq1_june26.py
+++ b/scripts/_1_4_9_rq1_june26.py
@@ -1,9 +1,26 @@
 from scripts._0_8_3_June_Collab_Comparison_Generation import main as gen_comp
 from bson import ObjectId
+from decouple import config
+import requests
 
+ADEPT_URL = config('ADEPT_URL')
+def rescore_observed_adms(observed_runs):
+    for adm in observed_runs:
+        results = adm.get('results', '')
+        sid = results.get('ta1_session_id', None)
+        target = adm.get('alignment_target')
+        existing_score = results.get('alignment_score')
 
-def rescore_observed_adms():
-    pass
+        payload = {'session_id': sid, 'target_id': target}
+        new_score = (requests.get(f'{ADEPT_URL}api/v1/alignment/session', params=payload))
+        print(new_score)
+        print(new_score.json())
+
+        if existing_score != new_score:
+            print('Difference In Scores \n')
+            print(f'New Score: {new_score}')
+            print(f'Existing Score: {existing_score}')
+            print(f'ADM Target: {target}')
 
 
 def main(mongo_db):
@@ -21,7 +38,8 @@ def main(mongo_db):
         object_ids = [ObjectId(oid) for oid in oid_strings]
         text_collec.delete_many({'_id': {'$in': object_ids}})
 
-
+    observed_adms = list(mongo_db['admTargetRuns'].find({'evalNumber': 17}))
     #re score observed adm run alignment scores
-    rescore_observed_adms()
+    rescore_observed_adms(observed_adms)
     #gen_comp(mongo_db, EVAL_NUMBER=17)
+    

--- a/scripts/_1_4_9_rq1_june26.py
+++ b/scripts/_1_4_9_rq1_june26.py
@@ -416,7 +416,7 @@ def write_discrepancies(adm_records, human_rows):
     print(f"  adm sheet:   {len(adm_out)} discrepancy row(s)")
     print(f"  human sheet: {len(human_out)} row(s) ({changed_count} changed)")
 
-def main(mongo_db, write_to_db=False):
+def main(mongo_db, write_to_db=True):
     text_collec = mongo_db[HUMAN_TEXT_COLLECTION]
     # pid to remove bad second run: 137, 148, 152, 160
     bad_text_docs = {
@@ -441,4 +441,5 @@ def main(mongo_db, write_to_db=False):
     if write_to_db:
         apply_medic_updates(mongo_db, adm_records)
         apply_human_updates(mongo_db, human_rows)
-    #gen_comp(mongo_db, EVAL_NUMBER=17)
+    
+    gen_comp(mongo_db, EVAL_NUMBER=17)


### PR DESCRIPTION
WARNING: This script will probably take about 2 hours to run in full. Part 1 will take 0.5 seconds, Part 2 will take about 20 minutes, and Part 3 will take the rest. Part 3 does not need to be run in full to confirm it is working correctly (maybe for about 10 minutes or so). 

### **Part 1** 
 Spurious text scenario results documents will be deleted. This can be checked via the participant progress page in the dashboard. There should be no participant for June 2026 with more than 6 text documents.

### **Part 2** 
 ADEPT changed their alignment scoring between Washington and Minnesota... The script will rescore all of the observed ADMs used in the delegation survey. That is, the alignment score between the ADM and its alignment target. Next, we will rescore the text scenario results of the humans as needed. None of the Minnesota stuff needs to be overwritten but as you'll see, there is a lot of Washington data that is affected. The affected data should now automatically be marked as exempt in the dashboard. All of these discrepancies will be added to an Excel file `eval17_rescore_discrepancies.xlsx` (this has already been passed to Jennifer).

Note: the ADM session IDs were wiped from the ADEPT server, so Part 2 creates new session IDs for them and replaces the session IDs in our database so that the comparison scores can be generated in Part 3.  

### **Part 3**
Finally, calculate the comparison scores between the humans and the observed ADMs. Each block, except for AF-SS, will have both a Binary and a trinary comparison. You don't need to let it finish running. You will know that you are in part three when your console looks like this:
<img width="474" height="220" alt="Screenshot 2026-07-01 at 12 09 08 PM" src="https://github.com/user-attachments/assets/84cf217a-c97b-4f30-9507-f2afdafecbd3" />

When this finishes running for me, I will post my results either here or in the dashboard channel so you can spot check with what you have run. [RQ-134 data_June2026.xlsx](https://github.com/user-attachments/files/29569311/RQ-134.data_June2026.xlsx)

`python deployment_script.py` or `python redo.py 149`


See [dashboard pr](https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/493)