### PR TITLE
ITM-1430: Ingest Feb2026-MF-PS2 yaml file

### DIFF
--- a/scripts/_1_5_6_add_feb_mf_ps2.py
+++ b/scripts/_1_5_6_add_feb_mf_ps2.py
@@ -1,0 +1,17 @@
+import os, yaml
+SCENARIOS_FOLDER = 'phase2/april2026/observe'
+def main(mongo_db):
+    path = os.path.join(SCENARIOS_FOLDER, 'feb2026-adept-observe-MF-PS2.yaml')
+    with open(path) as f:
+        yaml_obj = yaml.safe_load(f)
+        yaml_obj["evalNumber"] = 15
+        yaml_obj["evalName"] = "Phase 2 Feb 2026 Collaboration"
+
+    scenarios = mongo_db["scenarios"]
+    scenario_id = yaml_obj.get("id")
+
+    result = scenarios.replace_one(
+        {"id": scenario_id},
+        yaml_obj,
+        upsert=True
+    )


### PR DESCRIPTION
This YAML file needs to be added to the `scenarios` collection for these adm runs to populate on the adm probe responses page. ADEPT would like to review these adm runs. 

`python deployment_script.py` or `python redo.py 156`

Then go check out http://localhost:3000/adm-probe-responses. If you click on Feb 2026, you should now see `Feb2026-adept-observe-MF-PS2` as an option. Clicking on it should populate a baseline and an aligned table.