### PR TITLE
ITM-1428: remove bad adm runs

### DIFF
--- a/scripts/_1_5_7_more_bad_open_world_runs.py
+++ b/scripts/_1_5_7_more_bad_open_world_runs.py
@@ -1,0 +1,10 @@
+BAD_ADMS = [
+    "ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3__ef63fb05-905e-430c-8fad-3b253479979a",
+    "ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3__9a3be76d-a6b9-4d1d-ab3a-00b959b18331",
+    "ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3__c1f7bde7-5b14-48f4-bb5b-6a477b3dd868"
+]
+
+def main(mongo_db):
+    result = mongo_db['admTargetRuns'].delete_many({'adm_name': {'$in': BAD_ADMS}})
+
+    print(f'Deleted {result.deleted_count} bad adms')


### PR DESCRIPTION
The adm probe matcher already ran on these new runs, so all we are doing is deleting the adm runs that we were told are invalid. 

`python deployment_script.py` or `python redo.py 157`

Should delete 22 bad adm runs

[Dashboard pr](https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/516)