### PR TITLE
Delete open world test runs

### DIFF
--- a/scripts/_1_5_7_more_bad_open_world_runs.py
+++ b/scripts/_1_5_7_more_bad_open_world_runs.py
@@ -1,7 +1,9 @@
 BAD_ADMS = [
     "ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3__ef63fb05-905e-430c-8fad-3b253479979a",
     "ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3__9a3be76d-a6b9-4d1d-ab3a-00b959b18331",
-    "ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3__c1f7bde7-5b14-48f4-bb5b-6a477b3dd868"
+    "ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3__c1f7bde7-5b14-48f4-bb5b-6a477b3dd868",
+    "testrun",
+    "testrun-ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3__fbfe41ae-6991-4f55-b5ea-5a2dfc11b9cb"
 ]
 
 def main(mongo_db):


### PR DESCRIPTION
There are some test runs in the Open World ADM Part 2 dataset

<img width="1006" height="60" alt="Screenshot 2026-08-21 at 1 39 45 PM" src="https://github.com/user-attachments/assets/1ac7d928-56b3-440f-ad99-95424c50ad3e" />


Run this to delete them:
`python redo.py 157`

<img width="829" height="727" alt="Screenshot 2026-08-21 at 1 41 36 PM" src="https://github.com/user-attachments/assets/842e70ab-9c1c-4e7e-a1f6-1e4bda5c1b2e" />
