### PR TITLE
ITM-1436: Text-based Configs for Canada Triangle Exp

### DIFF
--- a/scripts/_1_6_0_add_canada_text_scenarios.py
+++ b/scripts/_1_6_0_add_canada_text_scenarios.py
@@ -8,4 +8,10 @@ def main(mongo_db):
             continue
         del config['_id']
         config['eval'] = 'Phase 2 Canada Evaluation'
+
+        for page in config['pages']:
+            page['elements'][0]['probe_unstructured'] = page['elements'][0]['probe_unstructured'].replace('They are a US warfighter from a different branch of the military than you.', 'They are Canadian military from a different branch than you.')
+            page['elements'][0]['probe_unstructured'] = page['elements'][0]['probe_unstructured'].replace('They are a warfighter in the same military unit as you.', 'They are Canadian military in the same unit as you.')
+            page['elements'][0]['probe_unstructured'] = page['elements'][0]['probe_unstructured'].replace('They are a foreign civilian contractor who works for the US military, but not your unit.', 'They are a foreign civilian contractor who works for the Canadian military, but not your unit.')
+            page['elements'][0]['probe_unstructured'] = page['elements'][0]['probe_unstructured'].replace('They are a warfighter in the same branch of the military as you, but not in the same unit.', 'They are Canadian military in the same branch as you, but not in the same unit.')
         mongo_db['textBasedConfig'].insert_one(config)

--- a/scripts/_1_6_0_add_canada_text_scenarios.py
+++ b/scripts/_1_6_0_add_canada_text_scenarios.py
@@ -1,0 +1,11 @@
+def main(mongo_db):
+    june_configs = list(mongo_db['textBasedConfig'].find({
+        'eval': 'Phase 2 June 2026 Evaluation'
+    }))
+
+    for config in june_configs:
+        if 'trinary' in config['scenario_id']:
+            continue
+        del config['_id']
+        config['eval'] = 'Phase 2 Canada Evaluation'
+        mongo_db['textBasedConfig'].insert_one(config)


### PR DESCRIPTION
`python redo.py 160` or `python deployment_script.py`


This creates the text-based configs for the Canadian portion of the triangle experiment. All of the configs are modified versions of the binomial probe sets from the June 2026 eval. See [dashboard pr](https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/520) after the script runs.