### PR TITLE
ITM-1441: KDMA Fetch For Trinary Compatibility Patch

### DIFF
--- a/june2026_probe_matcher.py
+++ b/june2026_probe_matcher.py
@@ -2769,7 +2769,7 @@ def extract_text_kdmas(metadata):
     for doc in docs_to_use:
         scenario_id = doc.get("scenario_id", "")
         kdmas, source_field = _extract_kdmas_from_doc(doc)
-        if not kdmas:
+        if not kdmas or 'trinary' in scenario_id:
             continue
 
         for kdma in kdmas:

--- a/june2026_probe_matcher.py
+++ b/june2026_probe_matcher.py
@@ -2722,45 +2722,48 @@ def _is_current_eval_text_doc(doc, metadata):
     )
 
 
-def _extract_kdmas_from_doc(doc):
-    """Return the best available KDMA array from a text scenario doc."""
-    if isinstance(doc.get("combinedKdmas"), list) and doc.get("combinedKdmas"):
-        return doc.get("combinedKdmas"), "combinedKdmas"
+def _binary_text_scenario_ids(metadata):
+    """Return the exact June binomial assessment ids for this evaluation."""
+    return {
+        scenario_id
+        for prefix in get_eval_prefix_candidates(metadata)
+        for kdma_name in KDMA_MAP.values()
+        for scenario_id in (
+            f"{prefix}-{kdma_name}-assess",
+            f"{prefix}_{kdma_name}_assess",
+        )
+    }
 
-    merged = []
-    for field_name in ["AF-PS_kdmas", "MF-PS_kdmas", "AF_SS_kdmas", "MF_SS_kdmas", "AF-SS_kdmas", "MF-SS_kdmas"]:
-        value = doc.get(field_name)
-        if isinstance(value, list) and value:
-            merged.extend(value)
-    if merged:
-        return merged, "merged_assess_kdmas"
 
-    for field_name in ["kdmas", "individualKdmas"]:
-        value = doc.get(field_name)
-        if isinstance(value, list) and value:
-            return value, field_name
+def _classify_text_kdma_doc(doc, metadata):
+    """Classify a text result by its exact assessment scenario id.
 
-    return [], None
+    ADEPT can represent binary KDMAs either as scalar ``value`` entries or as
+    ``intercept``/weight parameters, depending on the server version.  Payload
+    shape therefore cannot distinguish binary from trinary.  June trinary
+    documents are identified by their explicit ``-trinary``/``_trinary``
+    scenario-id suffix; exact non-trinary assessment ids are binary.
+    """
+    scenario_id = str(doc.get("scenario_id", "") or "").strip().lower()
+    if scenario_id.endswith(("-trinary", "_trinary")):
+        return "trinary"
+
+    binary_ids_lower = {
+        candidate.lower() for candidate in _binary_text_scenario_ids(metadata)
+    }
+    if scenario_id not in binary_ids_lower:
+        return "other"
+
+    return "binary"
 
 
 def extract_text_kdmas(metadata):
-    """Join scalar binomial and parameterized trinary text KDMAs.
-
-    June binomial profiles store AF/MF/PS/SS as ``{"kdma": ..., "value": ...}``.
-    June trinary profiles store AF/PS model coefficients in ``parameters``.
-    Preserve both shapes in distinct output fields.
-    """
+    """Extract parameterized AF/MF/PS/SS profiles from binary text documents."""
     text_kdma_results = {
-        f"Participant Text {short_name} KDMA": ""
-        for short_name in KDMA_MAP.values()
-    }
-    # Only AF and PS have June trinary assessments. ADEPT's multinomial
-    # profile exposes optA/optB rather than a single intercept.
-    text_kdma_results.update({
         f"Participant Text {short_name} {param_name} KDMA": ""
-        for short_name in ("AF", "PS")
-        for param_name in ["optA", "optB", "attr_weight", "medical_weight"]
-    })
+        for short_name in KDMA_MAP.values()
+        for param_name in ["intercept", "attr_weight", "medical_weight"]
+    }
 
     if text_scenario_collection is None:
         return text_kdma_results
@@ -2772,17 +2775,18 @@ def extract_text_kdmas(metadata):
 
     eval_number = get_eval_number(metadata)
     eval_name = get_eval_name(metadata)
-    prefixes = get_eval_prefix_candidates(metadata)
+    binary_scenario_ids = sorted(_binary_text_scenario_ids(metadata))
 
     text_docs = []
     seen_ids = set()
     queries = []
     for pid_val in pid_candidates:
-        queries.append({"participantID": pid_val, "evalNumber": eval_number})
-        queries.append({"participantID": pid_val, "evalName": eval_name})
-        for prefix in prefixes:
-            queries.append({"participantID": pid_val, "scenario_id": {"$regex": f"^{prefix}", "$options": "i"}})
-        queries.append({"participantID": pid_val})
+        # Exact ids prevent an ``*-assess`` lookup from also selecting
+        # ``*-assess-trinary`` documents.
+        scenario_query = {"$in": binary_scenario_ids}
+        queries.append({"participantID": pid_val, "evalNumber": eval_number, "scenario_id": scenario_query})
+        queries.append({"participantID": pid_val, "evalName": eval_name, "scenario_id": scenario_query})
+        queries.append({"participantID": pid_val, "scenario_id": scenario_query})
 
     try:
         for query in queries:
@@ -2800,34 +2804,40 @@ def extract_text_kdmas(metadata):
             print(f"Warning: No text scenario documents found for pid {pid}.")
         return text_kdma_results
 
-    preferred_docs = [doc for doc in text_docs if _is_current_eval_text_doc(doc, metadata)]
-    docs_to_use = preferred_docs if preferred_docs else text_docs
+    binary_docs = [doc for doc in text_docs if _classify_text_kdma_doc(doc, metadata) == "binary"]
+    rejected_docs = len(text_docs) - len(binary_docs)
+    if VERBOSE and rejected_docs:
+        logger.log(
+            LogLevel.INFO,
+            f"Ignored {rejected_docs} non-binary text KDMA document(s) for pid {pid}.",
+        )
+
+    preferred_docs = [doc for doc in binary_docs if _is_current_eval_text_doc(doc, metadata)]
+    docs_to_use = preferred_docs if preferred_docs else binary_docs
+    if not docs_to_use:
+        logger.log(LogLevel.WARN, f"No valid binomial text KDMA documents found for pid {pid}.")
+        return text_kdma_results
+
     docs_to_use.sort(
         key=lambda d: (
-            # Read binomial scalar profiles first, then trinary parameters.
-            1 if "trinary" in str(d.get("scenario_id", "")).lower() else 0,
-            0 if (isinstance(d.get("combinedKdmas"), list) and d.get("combinedKdmas")) else 1,
-            0 if _is_current_eval_text_doc(d, metadata) else 1,
             str(d.get("timeComplete", "")),
-        )
+            str(d.get("_id", "")),
+        ),
+        reverse=True,
     )
 
-    processed_profiles = set()
+    processed_sessions = set()
     for doc in docs_to_use:
         scenario_id = str(doc.get("scenario_id", "") or "")
-        kdmas, source_field = _extract_kdmas_from_doc(doc)
+        kdmas = doc.get("combinedKdmas", [])
         if not kdmas:
             continue
 
-        is_trinary = "trinary" in scenario_id.lower()
-        session_field = "combinedSessionId" if source_field == "combinedKdmas" else None
-        profile_identity = (
-            "trinary" if is_trinary else "binomial",
-            str(doc.get(session_field, "")) if session_field else source_field,
-        )
-        if profile_identity in processed_profiles:
+        session_id = str(doc.get("combinedSessionId", "") or "")
+        if session_id and session_id in processed_sessions:
             continue
-        processed_profiles.add(profile_identity)
+        if session_id:
+            processed_sessions.add(session_id)
 
         for kdma in kdmas:
             kdma_name = kdma.get("kdma")
@@ -2835,36 +2845,21 @@ def extract_text_kdmas(metadata):
                 continue
             short_name = KDMA_MAP[kdma_name]
 
-            # Binomial profiles expose one scalar value per KDMA.
-            if "value" in kdma and not isinstance(kdma.get("value"), (dict, list)):
-                scalar_key = f"Participant Text {short_name} KDMA"
-                scalar_value = kdma.get("value", "")
-                if text_kdma_results[scalar_key] not in ("", scalar_value):
-                    print(
-                        f"Warning: Duplicate text KDMA value for {scalar_key} on pid {pid}; "
-                        f"keeping {text_kdma_results[scalar_key]} and ignoring {scalar_value} "
-                        f"from {scenario_id} ({source_field})."
-                    )
-                else:
-                    text_kdma_results[scalar_key] = scalar_value
-
-            # Trinary profiles expose multinomial model coefficients for AF
-            # and PS. June has no MF/SS trinary assessments.
+            # Read only the binary binomial coefficient names from documents
+            # already classified by scenario_id as non-trinary.
             for param in kdma.get("parameters", []) or []:
                 param_name = param.get("name")
                 param_value = param.get("value", "")
-                if short_name not in {"AF", "PS"}:
-                    continue
-                if param_name not in {"optA", "optB", "attr_weight", "medical_weight"}:
+                if param_name not in {"intercept", "attr_weight", "medical_weight"}:
                     continue
                 key = f"Participant Text {short_name} {param_name} KDMA"
-                if key in text_kdma_results and text_kdma_results[key] not in ("", param_value):
+                if text_kdma_results[key] not in ("", param_value):
                     print(
                         f"Warning: Duplicate text KDMA value for {key} on pid {pid}; "
                         f"keeping {text_kdma_results[key]} and ignoring {param_value} "
-                        f"from {scenario_id} ({source_field})."
+                        f"from older binomial document {scenario_id}."
                     )
-                elif key in text_kdma_results:
+                else:
                     text_kdma_results[key] = param_value
 
     return text_kdma_results

--- a/june2026_probe_matcher.py
+++ b/june2026_probe_matcher.py
@@ -2387,11 +2387,13 @@ def get_ta1_calculations(scenario_id, probes):
         logger.log(LogLevel.WARN, "ADEPT_URL not set; skipping KDMA computation.")
         return None, None
     try:
-        session_id = requests.post(f"{ADEPT_URL}api/v1/new_session", timeout=120).text.replace('"', '').strip()
+        response = requests.post(f"{ADEPT_URL}api/v1/new_session", timeout=120)
+        response.raise_for_status()
+        session_id = response.text.replace('"', '').strip()
         if VERBOSE:
             logger.log(LogLevel.INFO, f"--> Sending probes: {probes}")
         for probe in probes:
-            requests.post(
+            response = requests.post(
                 f"{ADEPT_URL}api/v1/response",
                 json={
                     "response": {
@@ -2404,10 +2406,13 @@ def get_ta1_calculations(scenario_id, probes):
                 },
                 timeout=120,
             )
-        kdmas = requests.get(
+            response.raise_for_status()
+        response = requests.get(
             f"{ADEPT_URL}api/v1/computed_kdma_profile?session_id={session_id}",
             timeout=120,
-        ).json()
+        )
+        response.raise_for_status()
+        kdmas = response.json()
     except Exception as e:
         logger.log(LogLevel.WARN, f"TA1/KDMA request failed: {e}")
         return None, None
@@ -2548,7 +2553,12 @@ def compute_openworld_match_data(sim_json, metadata):
 
 
 def find_text_session_for_alignment(metadata, alignment_type):
-    """Find the matching MF/AF text combinedSessionId for alignment compare."""
+    """Find the binomial combinedSessionId used for MF/AF alignment.
+
+    Both comparisons intentionally use the session populated from all four
+    binomial text scenarios.  Scenario ids are matched exactly so an AF query
+    can never select ``June2026-AF-assess-trinary``.
+    """
     if text_scenario_collection is None:
         logger.log(LogLevel.WARN, f"text_scenario_collection is unavailable; cannot look up {alignment_type} text session.")
         return None
@@ -2565,22 +2575,24 @@ def find_text_session_for_alignment(metadata, alignment_type):
         scenario_candidates.append(f"{prefix}-{alignment_type}-assess")
         scenario_candidates.append(f"{prefix}_{alignment_type}_assess")
 
-    queries = []
-    for pid_val in pid_candidates:
-        for scenario_id in scenario_candidates:
-            queries.append({"evalNumber": eval_number, "participantID": pid_val, "scenario_id": scenario_id})
-            queries.append({"participantID": pid_val, "scenario_id": scenario_id})
-        # Fallbacks for naming differences.
-        queries.append({
+    # All candidates are exact binomial ids.  Do not use a broad expression
+    # such as ``AF.*assess`` because it also matches AF-assess-trinary.
+    queries = [
+        {
             "evalNumber": eval_number,
-            "participantID": pid_val,
-            "scenario_id": {"$regex": f"{alignment_type}.*assess", "$options": "i"},
-        })
-        queries.append({
+            "participantID": {"$in": pid_candidates},
+            "scenario_id": {"$in": scenario_candidates},
+        },
+        {
             "evalName": eval_name,
-            "participantID": pid_val,
-            "scenario_id": {"$regex": f"{alignment_type}.*assess", "$options": "i"},
-        })
+            "participantID": {"$in": pid_candidates},
+            "scenario_id": {"$in": scenario_candidates},
+        },
+        {
+            "participantID": {"$in": pid_candidates},
+            "scenario_id": {"$in": scenario_candidates},
+        },
+    ]
 
     for query in queries:
         try:
@@ -2594,13 +2606,29 @@ def find_text_session_for_alignment(metadata, alignment_type):
         if not text_doc:
             continue
 
+        selected_scenario = str(text_doc.get("scenario_id", ""))
+        if selected_scenario.lower().endswith("-trinary"):
+            logger.log(
+                LogLevel.ERROR,
+                f"Refusing trinary text document for {alignment_type} alignment: {selected_scenario}",
+            )
+            return None
+
         session_id = text_doc.get("combinedSessionId")
         if session_id:
             if VERBOSE:
-                logger.log(LogLevel.INFO, f"Retrieved combinedSessionId for {alignment_type}: {session_id}")
+                logger.log(
+                    LogLevel.INFO,
+                    f"Retrieved binomial combinedSessionId for {alignment_type} "
+                    f"from {selected_scenario}: {session_id}",
+                )
             return str(session_id)
 
-        logger.log(LogLevel.WARN, f"Found text document for {alignment_type} alignment but combinedSessionId was missing.")
+        logger.log(
+            LogLevel.WARN,
+            f"Found binomial text document {selected_scenario} for {alignment_type} "
+            "alignment but combinedSessionId was missing.",
+        )
         return None
 
     logger.log(LogLevel.WARN, f"Could not find text document for {alignment_type} alignment (pid={pid}, evalNumber={eval_number}).")
@@ -2644,7 +2672,12 @@ def get_alignment_compare_score(human_session_id, metadata, alignment_type):
             return None
         score_value = float(score)
         if math.isnan(score_value):
-            logger.log(LogLevel.WARN, f"{alignment_type} alignment compare returned NaN for pid {metadata.get('pid')}.")
+            logger.log(
+                LogLevel.WARN,
+                f"{alignment_type} alignment compare returned NaN for pid {metadata.get('pid')} "
+                f"(open-world session={human_session_id}, text session={text_session_id}, "
+                f"kdma_filter={kdma_filter}).",
+            )
             return None
         return score_value
     except Exception as e:
@@ -2711,12 +2744,23 @@ def _extract_kdmas_from_doc(doc):
 
 
 def extract_text_kdmas(metadata):
-    """Join text scenario KDMAs for the current eval, preferring combinedKdmas."""
+    """Join scalar binomial and parameterized trinary text KDMAs.
+
+    June binomial profiles store AF/MF/PS/SS as ``{"kdma": ..., "value": ...}``.
+    June trinary profiles store AF/PS model coefficients in ``parameters``.
+    Preserve both shapes in distinct output fields.
+    """
     text_kdma_results = {
-        f"Participant Text {short_name} {param_name} KDMA": ""
+        f"Participant Text {short_name} KDMA": ""
         for short_name in KDMA_MAP.values()
-        for param_name in ["intercept", "attr_weight", "medical_weight"]
     }
+    # Only AF and PS have June trinary assessments. ADEPT's multinomial
+    # profile exposes optA/optB rather than a single intercept.
+    text_kdma_results.update({
+        f"Participant Text {short_name} {param_name} KDMA": ""
+        for short_name in ("AF", "PS")
+        for param_name in ["optA", "optB", "attr_weight", "medical_weight"]
+    })
 
     if text_scenario_collection is None:
         return text_kdma_results
@@ -2760,38 +2804,68 @@ def extract_text_kdmas(metadata):
     docs_to_use = preferred_docs if preferred_docs else text_docs
     docs_to_use.sort(
         key=lambda d: (
+            # Read binomial scalar profiles first, then trinary parameters.
+            1 if "trinary" in str(d.get("scenario_id", "")).lower() else 0,
             0 if (isinstance(d.get("combinedKdmas"), list) and d.get("combinedKdmas")) else 1,
             0 if _is_current_eval_text_doc(d, metadata) else 1,
             str(d.get("timeComplete", "")),
         )
     )
 
+    processed_profiles = set()
     for doc in docs_to_use:
-        scenario_id = doc.get("scenario_id", "")
+        scenario_id = str(doc.get("scenario_id", "") or "")
         kdmas, source_field = _extract_kdmas_from_doc(doc)
-        if not kdmas or 'trinary' in scenario_id:
+        if not kdmas:
             continue
+
+        is_trinary = "trinary" in scenario_id.lower()
+        session_field = "combinedSessionId" if source_field == "combinedKdmas" else None
+        profile_identity = (
+            "trinary" if is_trinary else "binomial",
+            str(doc.get(session_field, "")) if session_field else source_field,
+        )
+        if profile_identity in processed_profiles:
+            continue
+        processed_profiles.add(profile_identity)
 
         for kdma in kdmas:
             kdma_name = kdma.get("kdma")
             if kdma_name not in KDMA_MAP:
                 continue
             short_name = KDMA_MAP[kdma_name]
+
+            # Binomial profiles expose one scalar value per KDMA.
+            if "value" in kdma and not isinstance(kdma.get("value"), (dict, list)):
+                scalar_key = f"Participant Text {short_name} KDMA"
+                scalar_value = kdma.get("value", "")
+                if text_kdma_results[scalar_key] not in ("", scalar_value):
+                    print(
+                        f"Warning: Duplicate text KDMA value for {scalar_key} on pid {pid}; "
+                        f"keeping {text_kdma_results[scalar_key]} and ignoring {scalar_value} "
+                        f"from {scenario_id} ({source_field})."
+                    )
+                else:
+                    text_kdma_results[scalar_key] = scalar_value
+
+            # Trinary profiles expose multinomial model coefficients for AF
+            # and PS. June has no MF/SS trinary assessments.
             for param in kdma.get("parameters", []) or []:
                 param_name = param.get("name")
                 param_value = param.get("value", "")
-                if not param_name:
+                if short_name not in {"AF", "PS"}:
+                    continue
+                if param_name not in {"optA", "optB", "attr_weight", "medical_weight"}:
                     continue
                 key = f"Participant Text {short_name} {param_name} KDMA"
                 if key in text_kdma_results and text_kdma_results[key] not in ("", param_value):
                     print(
                         f"Warning: Duplicate text KDMA value for {key} on pid {pid}; "
-                        f"overwriting {text_kdma_results[key]} with {param_value} from {scenario_id} ({source_field})."
+                        f"keeping {text_kdma_results[key]} and ignoring {param_value} "
+                        f"from {scenario_id} ({source_field})."
                     )
-                text_kdma_results[key] = param_value
-
-        if source_field == "combinedKdmas":
-            break
+                elif key in text_kdma_results:
+                    text_kdma_results[key] = param_value
 
     return text_kdma_results
 

--- a/june2026_text_repop.py
+++ b/june2026_text_repop.py
@@ -20,7 +20,7 @@ without creating sessions or updating Mongo.
 --timeout <seconds> ADEPT request timeout. Defaults to 120.
 --skip-af-ss Skip AF-SS_sessionId creation/update.
 --skip-trinary Skip trinary combinedSessionId creation/update.
---skip-mf-individual Skip MF individualSessionId creation/update.
+--create-mf-individual Also create the legacy MF individualSessionId.
 
 Examples:
 py june2026_text_repop.py --eval-number 17 --pid 202606112 --dry-run -v
@@ -528,10 +528,15 @@ def process_participant(
                 recreate_sessions=recreate_sessions,
             )
 
-            if trinary_sid and created:
+            if trinary_sid and created and trinary_kdmas is None:
+                log(
+                    "  Error: the new combined trinary session did not return a "
+                    "computed KDMA profile. Mongo will not be updated, preventing "
+                    "a new session id from being paired with stale combinedKdmas."
+                )
+            elif trinary_sid and created:
                 set_values = {"combinedSessionId": trinary_sid}
-                if trinary_kdmas is not None:
-                    set_values["combinedKdmas"] = trinary_kdmas
+                set_values["combinedKdmas"] = trinary_kdmas
                 update_documents(collection, trinary_docs, set_values, dry_run)
                 for old_sid in old_trinary_ids:
                     update_session_references(mongo_db, old_sid, trinary_sid, dry_run)
@@ -574,7 +579,12 @@ def main() -> int:
     parser.add_argument("--timeout", type=int, default=120)
     parser.add_argument("--skip-af-ss", action="store_true", help="Do not create/update AF-SS_sessionId")
     parser.add_argument("--skip-trinary", action="store_true", help="Do not create/update trinary combinedSessionId")
-    parser.add_argument("--skip-mf-individual", action="store_true", help="Do not create/update MF individualSessionId")
+    parser.add_argument(
+        "--create-mf-individual",
+        action="store_true",
+        help="Also create/update the legacy MF individualSessionId (not needed for open-world alignment)",
+    )
+    parser.add_argument("--skip-mf-individual", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
 
     if MongoClient is None:
@@ -631,7 +641,7 @@ def main() -> int:
                 verbose=args.verbose,
                 update_af_ss=not args.skip_af_ss,
                 update_trinary=not args.skip_trinary,
-                update_mf_individual=not args.skip_mf_individual,
+                update_mf_individual=args.create_mf_individual and not args.skip_mf_individual,
                 recreate_sessions=args.recreate_sessions,
             )
         except Exception as exc:

--- a/scripts/_1_6_0_june2026_repop_and_probe_match.py
+++ b/scripts/_1_6_0_june2026_repop_and_probe_match.py
@@ -1,0 +1,115 @@
+"""Repopulate June 2026 ADEPT sessions and rerun the production probe matcher.
+
+This migration is intentionally ordered:
+
+1. Recreate the June 2026 text sessions on the ADEPT server configured by
+   ``ADEPT_URL`` and write their session IDs/KDMAs to ``userScenarioResults``.
+2. Run the June 2026 probe matcher against the refreshed text sessions and
+   upsert its raw/analysis documents to Mongo.
+
+The deployment framework imports this file from ``scripts/`` and calls
+``main(mongo_db)``. The scripts being executed live in the repository root.
+"""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+try:
+    from decouple import config
+except ImportError:
+    def config(key, default=None, **kwargs):
+        return os.environ.get(key, default)
+
+
+EVAL_NUMBER = 17
+REPOP_SCRIPT = "june2026_text_repop.py"
+PROBE_MATCHER_SCRIPT = "june2026_probe_matcher.py"
+PROBE_INPUT_DIR = Path("ph2_sim_files") / "june2026"
+PROBE_OUTPUT_DIR = Path("output_june2026")
+
+
+def _require_configuration() -> None:
+    """Fail before changing data if required service settings are missing."""
+    mongo_url = str(config("MONGO_URL", default="") or "").strip()
+    adept_url = str(config("ADEPT_URL", default="") or "").strip()
+
+    if not mongo_url:
+        raise RuntimeError("MONGO_URL is not configured.")
+    if not adept_url:
+        raise RuntimeError("ADEPT_URL is not configured.")
+
+    print(f"Using ADEPT server: {adept_url}", flush=True)
+
+
+def _require_repo_paths(repo_root: Path) -> None:
+    """Verify the root-level scripts and June input data exist."""
+    required_paths = [
+        repo_root / REPOP_SCRIPT,
+        repo_root / PROBE_MATCHER_SCRIPT,
+        repo_root / PROBE_INPUT_DIR,
+    ]
+    missing = [str(path) for path in required_paths if not path.exists()]
+    if missing:
+        raise FileNotFoundError(
+            "Required June 2026 migration path(s) not found: " + ", ".join(missing)
+        )
+
+
+def _run(command, repo_root: Path, label: str) -> None:
+    """Run one required step and stop the migration if it fails."""
+    print(f"\n{label}", flush=True)
+    print("Command: " + " ".join(str(part) for part in command), flush=True)
+
+    environment = os.environ.copy()
+    environment["PYTHONUNBUFFERED"] = "1"
+    subprocess.run(
+        [str(part) for part in command],
+        cwd=str(repo_root),
+        env=environment,
+        check=True,
+    )
+
+
+def main(mongo_db):
+    """Run the June repopulation before regenerating probe-match documents."""
+    # ``mongo_db`` is supplied by deployment_script.py. The child scripts use
+    # the same production MONGO_URL from the environment/.env configuration.
+    if mongo_db is None:
+        raise RuntimeError("The deployment framework did not provide a Mongo database.")
+
+    repo_root = Path(__file__).resolve().parent.parent
+    _require_configuration()
+    _require_repo_paths(repo_root)
+
+    repop_command = [
+        sys.executable,
+        repo_root / REPOP_SCRIPT,
+        "--eval-number",
+        str(EVAL_NUMBER),
+        "--recreate-sessions",
+    ]
+    _run(
+        repop_command,
+        repo_root,
+        "Step 1/2: Recreating June 2026 text sessions on production ADEPT...",
+    )
+
+    matcher_command = [
+        sys.executable,
+        repo_root / PROBE_MATCHER_SCRIPT,
+        "--input_dir",
+        repo_root / PROBE_INPUT_DIR,
+        "--output_dir",
+        repo_root / PROBE_OUTPUT_DIR,
+        "--send_to_mongo",
+        "--calc_kdmas",
+    ]
+    _run(
+        matcher_command,
+        repo_root,
+        "Step 2/2: Recomputing June 2026 probe matches and Mongo documents...",
+    )
+
+    print("\nJune 2026 repopulation and probe matching completed successfully.", flush=True)


### PR DESCRIPTION
This PR updates the June 2026 repop and probe matcher scripts to support the addition of trinary sessions. It also includes a deployment script that runs the repop script and probe matcher back to back.

To test these changes, make sure you are using the latest version of the ADEPT server. Older versions will not return the expected KDMA values. Also verify that the ADEPT server’s `openapi_server/data/scenario/` directory contains all of the following files:

* `June2026-AF-assess.yaml`
* `June2026-MF-assess.yaml`
* `June2026-PS-assess.yaml`
* `June2026-SS-assess.yaml`
* `June2026-AF-assess-trinary.yaml`
* `June2026-PS-assess-trinary.yaml`
* `june2026-desert-openworld.yaml`
* `june2026-urban-openworld.yaml`

After adding these files, make sure the ADEPT server has been rebuilt so that they are included in the running server.

Once your environment is configured correctly, run:

`py redo.py 160`

This script will take some time to complete. After it finishes, use MongoDB Compass to query the `humanSimulator` collection with `{evalNumber: 17}`. Spot-check the returned documents and confirm that the values in `text_kdmas` are populated and that the values in `alignment_scores` are not empty or `null`.
